### PR TITLE
[build] LRT optional for Linux for shm

### DIFF
--- a/tools/shm/BUILD
+++ b/tools/shm/BUILD
@@ -9,9 +9,10 @@ package(default_visibility = ["//visibility:public"])
 cc_binary(
     name = "clean",
     srcs = ["clean.cpp"],
-    linkopts = [
-        "-lrt",
-    ],
+    linkopts = select({
+        "//:linux": ["-lrt"],
+        "@//conditions:default": [],
+    }),
     deps = [
         "@spdlog",
     ],


### PR DESCRIPTION
Was this missed during https://github.com/tasts-robots/vulp/commit/ba42733a78e7726c5586053c8061c689aa581ef5 , or was it deliberate ? 