### PR TITLE
Fix IMU orientation reporting in Bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Improve test coverage
 
+### Fixed
+
+- Bullet interface now reports the IMU orientation in the proper ARS frame
+
 ## [1.2.0] - 2023/06/06
 
 ### Added

--- a/actuation/ImuData.h
+++ b/actuation/ImuData.h
@@ -23,7 +23,12 @@ namespace vulp::actuation {
 
 //! Data filtered from an onboard IMU such as the pi3hat's.
 struct ImuData {
-  //! Orientation from the IMU frame to the world frame.
+  /*! Orientation from the IMU frame to the attitude reference system (ARS) frame.
+   *
+   * The attitude reference system frame has +x forward, +y right and +z down,
+   * whereas our world frame has +x forward, +y left and +z up:
+   * https://github.com/mjbots/pi3hat/blob/ab632c82bd501b9fcb6f8200df0551989292b7a1/docs/reference.md#orientation
+   */
   Eigen::Quaterniond orientation_imu_in_ars = Eigen::Quaterniond::Identity();
 
   /*! Body angular velocity of the IMU frame in [rad] / [s].

--- a/actuation/ImuData.h
+++ b/actuation/ImuData.h
@@ -24,7 +24,7 @@ namespace vulp::actuation {
 //! Data filtered from an onboard IMU such as the pi3hat's.
 struct ImuData {
   //! Orientation from the IMU frame to the world frame.
-  Eigen::Quaterniond orientation_imu_in_world = Eigen::Quaterniond::Identity();
+  Eigen::Quaterniond orientation_imu_in_ars = Eigen::Quaterniond::Identity();
 
   /*! Body angular velocity of the IMU frame in [rad] / [s].
    *

--- a/actuation/ImuData.h
+++ b/actuation/ImuData.h
@@ -23,7 +23,8 @@ namespace vulp::actuation {
 
 //! Data filtered from an onboard IMU such as the pi3hat's.
 struct ImuData {
-  /*! Orientation from the IMU frame to the attitude reference system (ARS) frame.
+  /*! Orientation from the IMU frame to the attitude reference system (ARS)
+   * frame.
    *
    * The attitude reference system frame has +x forward, +y right and +z down,
    * whereas our world frame has +x forward, +y left and +z up:

--- a/actuation/MockInterface.h
+++ b/actuation/MockInterface.h
@@ -60,7 +60,7 @@ class MockInterface : public Interface {
 
   //! Orientation from the IMU frame to the world frame.
   Eigen::Quaterniond get_attitude() const noexcept {
-    return imu_data_.orientation_imu_in_world;
+    return imu_data_.orientation_imu_in_ars;
   }
 
   //! Body angular velocity of the IMU frame in [rad] / [s].

--- a/actuation/Pi3HatInterface.h
+++ b/actuation/Pi3HatInterface.h
@@ -126,7 +126,7 @@ class Pi3HatInterface : public Interface {
   //! Get the pi3hat's IMU attitude
   ImuData imu_data() const noexcept final {
     ImuData imu_data;
-    imu_data.orientation_imu_in_world = get_attitude();
+    imu_data.orientation_imu_in_ars = get_attitude();
     imu_data.angular_velocity_imu_in_imu = get_angular_velocity();
     imu_data.linear_acceleration_imu_in_imu = get_linear_acceleration();
     return imu_data;

--- a/actuation/bullet_utils.h
+++ b/actuation/bullet_utils.h
@@ -113,8 +113,10 @@ inline void read_imu_data(BulletImuData& imu_data,
   Eigen::Matrix3d rotation_world_to_ars =
       Eigen::Vector3d{1.0, -1.0, -1.0}.asDiagonal();
 
-  Eigen::Matrix3d rotation_imu_to_world = orientation_imu_in_world.toRotationMatrix();
-  Eigen::Matrix3d rotation_imu_to_ars = rotation_world_to_ars * rotation_imu_to_world;
+  Eigen::Matrix3d rotation_imu_to_world =
+      orientation_imu_in_world.toRotationMatrix();
+  Eigen::Matrix3d rotation_imu_to_ars =
+      rotation_world_to_ars * rotation_imu_to_world;
   Eigen::Quaterniond orientation_imu_in_ars(rotation_imu_to_ars);
 
   Eigen::Vector3d linear_velocity_imu_in_world = {
@@ -134,9 +136,12 @@ inline void read_imu_data(BulletImuData& imu_data,
   Eigen::Vector3d linear_acceleration_imu_in_world =
       (linear_velocity_imu_in_world - previous_linear_velocity) / dt;
 
-  Eigen::Matrix3d rotation_world_to_imu = orientation_imu_in_world.normalized().inverse();
-  Eigen::Vector3d angular_velocity_imu_in_imu = rotation_world_to_imu * angular_velocity_imu_to_world_in_world;
-  Eigen::Vector3d linear_acceleration_imu_in_imu = rotation_world_to_imu * linear_acceleration_imu_in_world;
+  Eigen::Matrix3d rotation_world_to_imu =
+      orientation_imu_in_world.normalized().inverse();
+  Eigen::Vector3d angular_velocity_imu_in_imu =
+      rotation_world_to_imu * angular_velocity_imu_to_world_in_world;
+  Eigen::Vector3d linear_acceleration_imu_in_imu =
+      rotation_world_to_imu * linear_acceleration_imu_in_world;
 
   // Fill out regular IMU data
   imu_data.orientation_imu_in_ars = orientation_imu_in_ars;

--- a/actuation/bullet_utils.h
+++ b/actuation/bullet_utils.h
@@ -136,8 +136,7 @@ inline void read_imu_data(BulletImuData& imu_data,
   Eigen::Vector3d linear_acceleration_imu_in_world =
       (linear_velocity_imu_in_world - previous_linear_velocity) / dt;
 
-  Eigen::Matrix3d rotation_world_to_imu =
-      orientation_imu_in_world.normalized().inverse();
+  auto rotation_world_to_imu = orientation_imu_in_world.normalized().inverse();
   Eigen::Vector3d angular_velocity_imu_in_imu =
       rotation_world_to_imu * angular_velocity_imu_to_world_in_world;
   Eigen::Vector3d linear_acceleration_imu_in_imu =

--- a/actuation/bullet_utils.h
+++ b/actuation/bullet_utils.h
@@ -122,6 +122,7 @@ inline void read_imu_data(BulletImuData& imu_data,
       link_state.m_worldLinearVelocity[1],
       link_state.m_worldLinearVelocity[2],
   };
+
   Eigen::Vector3d angular_velocity_imu_to_world_in_world = {
       link_state.m_worldAngularVelocity[0],
       link_state.m_worldAngularVelocity[1],
@@ -133,12 +134,16 @@ inline void read_imu_data(BulletImuData& imu_data,
   Eigen::Vector3d linear_acceleration_imu_in_world =
       (linear_velocity_imu_in_world - previous_linear_velocity) / dt;
 
-  auto rotation_world_to_imu =
-      imu_data.orientation_imu_in_world.normalized().inverse();
-  imu_data.angular_velocity_imu_in_imu =
-      rotation_world_to_imu * angular_velocity_imu_to_world_in_world;
-  imu_data.linear_acceleration_imu_in_imu =
-      rotation_world_to_imu * linear_acceleration_imu_in_world;
+  Eigen::Matrix3d rotation_world_to_imu = orientation_imu_in_world.normalized().inverse();
+  Eigen::Vector3d angular_velocity_imu_in_imu = rotation_world_to_imu * angular_velocity_imu_to_world_in_world;
+  Eigen::Vector3d linear_acceleration_imu_in_imu = rotation_world_to_imu * linear_acceleration_imu_in_world;
+
+  // Fill out regular IMU data
+  imu_data.orientation_imu_in_ars = orientation_imu_in_ars;
+  imu_data.angular_velocity_imu_in_imu = angular_velocity_imu_in_imu;
+  imu_data.linear_acceleration_imu_in_imu = linear_acceleration_imu_in_imu;
+
+  // ... and the extra field for the Bullet interface
   imu_data.linear_velocity_imu_in_world = linear_velocity_imu_in_world;
 }
 

--- a/observation/observe_imu.cpp
+++ b/observation/observe_imu.cpp
@@ -23,7 +23,7 @@ namespace vulp::observation {
 void observe_imu(Dictionary& observation, const actuation::ImuData& imu_data) {
   // Eigen quaternions are serialized as [w, x, y, z]
   // See include/palimpsest/mpack/eigen.h in @palimpsest
-  observation("imu")("orientation") = imu_data.orientation_imu_in_world;
+  observation("imu")("orientation") = imu_data.orientation_imu_in_ars;
   observation("imu")("angular_velocity") = imu_data.angular_velocity_imu_in_imu;
   observation("imu")("linear_acceleration") =
       imu_data.linear_acceleration_imu_in_imu;

--- a/observation/tests/observe_imu_test.cpp
+++ b/observation/tests/observe_imu_test.cpp
@@ -32,7 +32,7 @@ namespace vulp::observation::tests {
 
 TEST(IMU, ReadOrientation) {
   actuation::ImuData imu_data;
-  imu_data.orientation_imu_in_world = Eigen::Quaterniond(0., 1., 0., 0.);
+  imu_data.orientation_imu_in_ars = Eigen::Quaterniond(0., 1., 0., 0.);
 
   Dictionary observation;
   observe_imu(observation, imu_data);
@@ -40,7 +40,7 @@ TEST(IMU, ReadOrientation) {
   ASSERT_TRUE(observation("imu").has("orientation"));
   ASSERT_TRUE(observation("imu")("orientation")
                   .as<Eigen::Quaterniond>()
-                  .isApprox(imu_data.orientation_imu_in_world));
+                  .isApprox(imu_data.orientation_imu_in_ars));
 }
 
 }  // namespace vulp::observation::tests


### PR DESCRIPTION
The IMU orientation is with respect to the [attitude reference system (ARS) frame](https://github.com/mjbots/pi3hat/blob/master/docs/reference.md#orientation), not our conventional world frame.