### PR TITLE
Support macOS operating system

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,7 @@ test --compilation_mode=opt
 test --copt="-Werror=return-type"
 test --cxxopt=-std=c++17
 test --test_output=errors
+test --test_tag_filters=-lint
 
 ## Linter
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,7 @@ test --test_output=errors
 
 ## Linter
 
-# Usage: bazel test --config lint //...)
+# Usage: bazel test --config lint //...
 test:lint --build_tests_only
 test:lint --test_tag_filters=lint
 

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -26,11 +26,7 @@ jobs:
                   tools/bazelisk build --compilation_mode=fastbuild //...
 
     coverage:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
+        runs-on: ubuntu-latest
         steps:
             - name: "Checkout sources"
               uses: actions/checkout@v2
@@ -48,11 +44,7 @@ jobs:
                   path-to-lcov: ${{ github.workspace }}/bazel-out/_coverage/_coverage_report.dat
 
     lint:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
+        runs-on: ubuntu-latest
         steps:
             - name: "Checkout sources"
               uses: actions/checkout@v2

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -55,7 +55,7 @@ jobs:
               env:
                   BAZELISK_GITHUB_TOKEN: ${{ secrets.BAZELISK_GITHUB_TOKEN }}
               run: |
-                  tools/bazelisk test  --compilation_mode=fastbuild --config lint //...
+                  tools/bazelisk test --compilation_mode=fastbuild --config lint //...
 
     test:
         runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bazel-vulp
 build
 coverage
 doc/html
+tools/bazel

--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,11 @@ config_setting(
 )
 
 config_setting(
+    name = "osx",
+    constraint_values = ["@platforms//os:osx"],
+)
+
+config_setting(
     name = "pi32_config",
     values = {
         "cpu": "armeabihf",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Set default compilation mode to optimized rather than fast build
 
+### Fixed
+
+- Bazel: only run lint tests when ``--config lint`` is provided
+
 ## [1.2.1] - 2023/07/07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Virtual destructor to the main ``Interface`` class
+
 ### Changed
 
 - Set default compilation mode to optimized rather than fast build

--- a/actuation/Interface.cpp
+++ b/actuation/Interface.cpp
@@ -44,7 +44,7 @@ constexpr double kKpScale = 1.0;
 // TODO(scaron): this is a sane default for a qdd100, not for weaker servos
 constexpr double kMaximumTorque = 8.42;  // N.m
 
-constexpr double kVelocity = 0.0;        // rad/s
+constexpr double kVelocity = 0.0;  // rad/s
 
 }  // namespace defaults
 

--- a/actuation/Interface.h
+++ b/actuation/Interface.h
@@ -54,6 +54,9 @@ class Interface {
     data_.replies = {replies_.data(), replies_.size()};
   }
 
+  //! Virtual destructor so that derived destructors are called properly.
+  virtual ~Interface() = default;
+
   /*! Spin a new communication cycle.
    *
    * \param[in, out] data Buffer to read commands from and write replies to.

--- a/observation/sources/BUILD
+++ b/observation/sources/BUILD
@@ -19,13 +19,13 @@ cc_library(
 cc_library(
     name = "joystick",
     hdrs = select({
-                "//:linux": ["Joystick.h"],
-                "@//conditions:default": [],
-            }),
+        "@//:linux": ["Joystick.h"],
+        "@//conditions:default": [],
+    }),
     srcs = select({
-                "//:linux": ["Joystick.cpp"],
-                "@//conditions:default": [],
-            }),
+        "@//:linux": ["Joystick.cpp"],
+        "@//conditions:default": [],
+    }),
     deps = [
         "//observation:source",
     ],
@@ -35,9 +35,9 @@ cc_library(
 cc_library(
     name = "sources",
     deps =  select({
-                "//:linux": [":joystick", ":cpu_temperature"],
-                "@//conditions:default": [":cpu_temperature"],
-            }),
+        "@//:linux": [":joystick", ":cpu_temperature"],
+        "@//conditions:default": [":cpu_temperature"],
+    }),
 )
 
 add_lint_tests()

--- a/observation/sources/tests/BUILD
+++ b/observation/sources/tests/BUILD
@@ -9,15 +9,15 @@ package(default_visibility = ["//visibility:public"])
 cc_test(
     name = "tests",
     srcs = select({
-                "//:linux": glob([
-                        "*.cpp",
-                        "*.h",
-                    ]), 
-                "@//conditions:default": glob([
-                        "*.cpp",
-                        "*.h",
-                    ], exclude=["JoystickTest.cpp"]),
-            }),
+        "@//:linux": glob([
+            "*.cpp",
+            "*.h",
+        ]),
+        "@//conditions:default": glob([
+            "*.cpp",
+            "*.h",
+        ], exclude=["JoystickTest.cpp"]),
+    }),
     deps = [
         "//observation/sources",
         "@googletest//:main",

--- a/spine/BUILD
+++ b/spine/BUILD
@@ -54,7 +54,7 @@ cc_library(
         "Spine.cpp",
     ],
     linkopts = select({
-        "//:linux": ["-lrt"],
+        "@//:linux": ["-lrt"],
         "@//conditions:default": [],
     }),
     deps = [

--- a/spine/tests/AgentInterfaceTest.cpp
+++ b/spine/tests/AgentInterfaceTest.cpp
@@ -37,7 +37,7 @@ class AgentInterfaceTest : public ::testing::Test {
         std::make_unique<AgentInterface>("/" + utils::random_string(), 1024);
   }
 
-  void TearDown() {}
+  void TearDown() override {}
 
   std::unique_ptr<AgentInterface> agent_interface_;
 };

--- a/spine/tests/SpineTest.cpp
+++ b/spine/tests/SpineTest.cpp
@@ -89,9 +89,6 @@ class SpineTest : public ::testing::Test {
  protected:
   //! Initialize spine for a new test
   void SetUp() override {
-    const auto* test_info =
-        ::testing::UnitTest::GetInstance()->current_test_info();
-
     params_.cpu = -1;         // no realtime scheduling
     params_.frequency = 400;  // Hz
     params_.shm_name = std::string("/") + utils::random_string();

--- a/spine/tests/SpineTest.cpp
+++ b/spine/tests/SpineTest.cpp
@@ -113,7 +113,7 @@ class SpineTest : public ::testing::Test {
     ASSERT_GE(::close(file_descriptor), 0);
   }
 
-  void TearDown() {
+  void TearDown() override {
     ASSERT_GE(::munmap(mmap_, params_.shm_size), 0);
 
     // Check that the destructor unlinks shared memory

--- a/spine/tests/StateMachineTest.cpp
+++ b/spine/tests/StateMachineTest.cpp
@@ -31,8 +31,6 @@ class StateMachineTest : public ::testing::Test {
  protected:
   //! Prepare state machine for a new test
   void SetUp() override {
-    const auto* test_info =
-        ::testing::UnitTest::GetInstance()->current_test_info();
     const size_t shm_size = 1 * (1 << 20);
     const std::string shm_name = std::string("/") + utils::random_string();
     agent_interface_ = std::make_unique<AgentInterface>(shm_name, shm_size);

--- a/tools/bazelisk
+++ b/tools/bazelisk
@@ -2,6 +2,7 @@
 #
 # Copyright 2018 The Bazel Authors
 # Copyright 2022 Stéphane Caron
+# Copyright 2023 Inria
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,13 +35,21 @@ os="$(uname -s | tr "[:upper:]" "[:lower:]")"
 readonly os
 
 # Value of BAZELISK_GITHUB_TOKEN is set as a secret in the GitHub workflow.
-readonly bazelisk_version="v1.6.1"
-readonly url="https://github.com/bazelbuild/bazelisk/releases/download/${bazelisk_version}/bazelisk-${os}-amd64"
-bazel="${TMPDIR:-/tmp}/bazelisk"
+readonly BAZELISK_VERSION="v1.16.0"
+readonly BAZELISK_URL="https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-${os}-amd64"
+
+readonly CURDIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+bazel="${CURDIR}/bazel"
 readonly bazel
 
-curl -L -sSf -o "${bazel}" "${url}"
-chmod a+x "${bazel}"
+if [ -f "${bazel}" ]; then
+    echo "Using existing Bazel binary from ${bazel}..."
+else
+    echo "Downloading Bazel binary from ${BAZELISK_URL}..."
+    curl -L -Sf --progress-bar -o "${bazel}" "${BAZELISK_URL}"
+    chmod a+x "${bazel}"
+fi
 
 set -x
 "${bazel}" version

--- a/tools/lint/clang_format_lint.py
+++ b/tools/lint/clang_format_lint.py
@@ -44,12 +44,15 @@ def _is_cxx(filename):
 def get_clang_format_path():
     """Get path to clang-format."""
     if platform.system() == "Darwin":
-        candidates = glob.glob(
-            "/opt/homebrew/*/clang-format/**/bin/clang-format",
-            recursive=True,
+        candidates = (
+            glob.glob(
+                "/opt/homebrew/*/clang-format/**/bin/clang-format",
+                recursive=True,
+            )
+            + ["/usr/local/opt/clang-format/bin/clang-format"]
         )
         if len(candidates) < 1:
-            raise RuntimeError("clang-format not found in {homebrew}")
+            raise RuntimeError("clang-format not found in homebrew paths")
         elif len(candidates) > 1:
             print(
                 f"WARNING: multiple versions of clang-format: {candidates},"

--- a/tools/pypi/pyproject.toml
+++ b/tools/pypi/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "msgpack >=1.0.2",
-    "posix_ipc >=1.0.5",
+    "posix_ipc >=1.1.1",
 ]
 keywords = ["motion control", "real time", "robotics"]
 

--- a/tools/shm/BUILD
+++ b/tools/shm/BUILD
@@ -10,7 +10,7 @@ cc_binary(
     name = "clean",
     srcs = ["clean.cpp"],
     linkopts = select({
-        "//:linux": ["-lrt"],
+        "@//:linux": ["-lrt"],
         "@//conditions:default": [],
     }),
     deps = [

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -40,11 +40,22 @@ bullet_copts = [
 
 bullet_defines = [
     "BT_USE_DOUBLE_PRECISION",
-    "DYNAMIC_LOAD_X11_FUNCTIONS=1",
-    "GLEW_DYNAMIC_LOAD_ALL_GLX_FUNCTIONS=1",
-    "GLEW_INIT_OPENGL11_FUNCTIONS=1",
-    "GLEW_STATIC",
-]
+] + select({
+    "@//:linux": [
+        "DYNAMIC_LOAD_X11_FUNCTIONS=1",
+        "GLEW_DYNAMIC_LOAD_ALL_GLX_FUNCTIONS=1",
+        "GLEW_INIT_OPENGL11_FUNCTIONS=1",
+        "GLEW_STATIC",
+        "HAS_SOCKLEN_T",
+        "_LINUX",
+    ],
+    "@//:osx": [
+        "B3_NO_PYTHON_FRAMEWORK",
+        "HAS_SOCKLEN_T",
+        "_DARWIN",
+    ],
+    "@//conditions:default": [],
+})
 
 cc_library(
     name = "src",

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -219,7 +219,7 @@ objc_library(
         "examples/OpenGLWindow/MacOpenGLWindowObjC.m",
     ],
     hdrs = [
-        "examples/OpenGLWindow/MacOpenGLWindowObjC.h",
+        "examples/OpenGLWindow/**/*.h",
     ],
     deps = [
         ":common_interfaces",

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -232,9 +232,33 @@ objc_library(
 
 cc_library(
     name = "opengl_window",
-    srcs = glob([
-        "examples/OpenGLWindow/**/*.cpp",
-    ]),
+    srcs = [
+        "examples/OpenGLWindow/EGLOpenGLWindow.cpp",
+        "examples/OpenGLWindow/fontstash.cpp",
+        "examples/OpenGLWindow/GLFWOpenGLWindow.cpp",
+        "examples/OpenGLWindow/GLInstancingRenderer.cpp",
+        "examples/OpenGLWindow/GLPrimitiveRenderer.cpp",
+        "examples/OpenGLWindow/GLRenderToTexture.cpp",
+        "examples/OpenGLWindow/LoadShader.cpp",
+        "examples/OpenGLWindow/opengl_fontstashcallbacks.cpp",
+        "examples/OpenGLWindow/OpenSans.cpp",
+        "examples/OpenGLWindow/SimpleCamera.cpp",
+        "examples/OpenGLWindow/SimpleOpenGL2App.cpp",
+        "examples/OpenGLWindow/SimpleOpenGL2Renderer.cpp",
+        "examples/OpenGLWindow/SimpleOpenGL3App.cpp",
+        "examples/OpenGLWindow/TwFonts.cpp",
+    ] + select({
+        "@//:linux": [
+            "examples/OpenGLWindow/X11OpenGLWindow.cpp",
+        ],
+        "@//:osx": [
+            "examples/OpenGLWindow/MacOpenGLWindow.cpp",
+        ],
+        # Windows is not supported:
+        # "examples/OpenGLWindow/Win32OpenGLWindow.cpp",
+        # "examples/OpenGLWindow/Win32Window.cpp",
+        "@//conditions:default": [],
+    }),
     hdrs = glob([
         "examples/OpenGLWindow/**/*.h",
     ]),
@@ -244,7 +268,11 @@ cc_library(
         ":glad",
         ":src",
         ":stb_image",
-    ],
+    ] + select({
+        "@//:linux": [],
+        "@//:osx": [":mac_opengl_window"],
+        "@//conditions:default": [],
+    }),
     copts = bullet_copts,
     linkopts = bullet_linkopts,
 )

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -57,6 +57,15 @@ bullet_defines = [
     "@//conditions:default": [],
 })
 
+bullet_linkopts = select({
+    "@//:osx": [
+        # Issue errors at link time rather than at run time
+        # See https://groups.google.com/g/bazel-discuss/c/YGVWGnhFEXc
+        "-Wl,-undefined,error",
+    ],
+    "@//conditions:default": [],
+})
+
 cc_library(
     name = "src",
     srcs = glob([
@@ -81,6 +90,7 @@ cc_library(
     defines = bullet_defines,
     includes = ["src"],
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -100,6 +110,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -121,6 +132,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -134,6 +146,7 @@ cc_library(
     strip_include_prefix = "examples/ThirdPartyLibs",
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -144,6 +157,7 @@ cc_library(
     strip_include_prefix = "examples/ThirdPartyLibs/optionalX11",
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -160,7 +174,7 @@ cc_library(
     strip_include_prefix = "examples/ThirdPartyLibs/glad",
     defines = bullet_defines,
     copts = bullet_copts,
-    linkopts = [
+    linkopts = bullet_linkopts + [
         "-ldl",
         "-lm",
     ],
@@ -180,6 +194,7 @@ cc_library(
     includes = ["examples/ThirdPartyLibs"],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -213,6 +228,7 @@ cc_library(
         ":stb_image",
     ],
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -238,6 +254,7 @@ cc_library(
     strip_include_prefix = "examples/ExampleBrowser",
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -256,6 +273,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -274,6 +292,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -296,6 +315,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -365,6 +385,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -391,6 +412,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -426,6 +448,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -447,6 +470,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -463,6 +487,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -479,6 +504,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -495,6 +521,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -511,6 +538,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -529,6 +557,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -549,6 +578,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -568,6 +598,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -585,6 +616,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -607,6 +639,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -636,6 +669,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -655,6 +689,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -675,6 +710,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -693,6 +729,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -709,6 +746,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -725,6 +763,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -741,6 +780,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -758,6 +798,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -770,6 +811,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -818,6 +860,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -837,6 +880,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -856,6 +900,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -873,6 +918,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -892,6 +938,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -910,6 +957,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -929,6 +977,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -945,6 +994,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(
@@ -1098,6 +1148,7 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
 )
 
 cc_library(

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -218,9 +218,9 @@ objc_library(
     non_arc_srcs = [
         "examples/OpenGLWindow/MacOpenGLWindowObjC.m",
     ],
-    hdrs = [
+    hdrs = glob([
         "examples/OpenGLWindow/**/*.h",
-    ],
+    ]),
     deps = [
         ":common_interfaces",
         ":glad",

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -20,15 +20,23 @@ genrule(
     echo $(COMPILATION_MODE) > $@""",
 )
 
-# Disable Bullet warnings
 bullet_copts = [
     "-Wno-all",
+    "-Wno-deprecated-declarations",
     "-Wno-error=unused-but-set-variable",
     "-Wno-error=unused-variable",
-    "-Wno-format-overflow",
-    "-Wno-format-truncation",
     "-Wno-unused-result",
-]
+] + select({
+    "@//:linux": [
+        "-Wno-format-overflow",
+        "-Wno-format-truncation",
+    ],
+    "@//:osx": [
+        # See https://github.com/libigl/libigl/issues/751#issuecomment-383324059
+        "-fno-common",
+    ],
+    "@//conditions:default": [],
+})
 
 bullet_defines = [
     "BT_USE_DOUBLE_PRECISION",

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -59,6 +59,9 @@ bullet_defines = [
 
 bullet_linkopts = select({
     "@//:osx": [
+        "-framework Cocoa",
+        "-framework OpenGL",
+        "-ldl",
         # Issue errors at link time rather than at run time
         # See https://groups.google.com/g/bazel-discuss/c/YGVWGnhFEXc
         "-Wl,-undefined,error",

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -210,6 +210,24 @@ cc_library(
     ],
     defines = bullet_defines,
     copts = bullet_copts,
+    linkopts = bullet_linkopts,
+)
+
+objc_library(
+    name = "mac_opengl_window",
+    non_arc_srcs = [
+        "examples/OpenGLWindow/MacOpenGLWindowObjC.m",
+    ],
+    hdrs = [
+        "examples/OpenGLWindow/MacOpenGLWindowObjC.h",
+    ],
+    deps = [
+        ":common_interfaces",
+        ":glad",
+    ],
+    target_compatible_with = [
+        "@platforms//os:osx",
+    ],
 )
 
 cc_library(

--- a/tools/workspace/bullet/package.BUILD
+++ b/tools/workspace/bullet/package.BUILD
@@ -51,6 +51,7 @@ bullet_defines = [
     ],
     "@//:osx": [
         "B3_NO_PYTHON_FRAMEWORK",
+        "GLEW_STATIC",
         "HAS_SOCKLEN_T",
         "_DARWIN",
     ],

--- a/tools/workspace/pip_vulp/requirements_lock.txt
+++ b/tools/workspace/pip_vulp/requirements_lock.txt
@@ -1,3 +1,3 @@
 msgpack==1.0.2
-posix_ipc==1.0.5
+posix_ipc==1.1.1
 setuptools==67.4.0

--- a/utils/tests/BUILD
+++ b/utils/tests/BUILD
@@ -9,15 +9,15 @@ package(default_visibility = ["//visibility:public"])
 cc_test(
     name = "tests",
     srcs = select({
-            "//:linux": glob([
-                    "*.cpp",
-                    "*.h",
-                ]),
-            "@//conditions:default": glob([
-                    "*.cpp",
-                    "*.h",
-                ], exclude=["realtime_test.cpp"]),
-        }),
+        "@//:linux": glob([
+            "*.cpp",
+            "*.h",
+        ]),
+        "@//conditions:default": glob([
+            "*.cpp",
+            "*.h",
+        ], exclude=["realtime_test.cpp"]),
+    }),
     deps = [
         "//utils",
         "@eigen",


### PR DESCRIPTION
Compiling Bullet with Bazel for macOS will require a few updates to the corresponding ``package.BUILD`` file.

This PR gathers the required compilation flags from Bullet's [`setup.py`](https://github.com/bulletphysics/bullet3/blob/39b8de74df93721add193e5b3d9ebee579faebf8/setup.py).

@boragokbakan FYI.