### PR TITLE
[minor] posix_ipc version

### DIFF
--- a/tools/pypi/pyproject.toml
+++ b/tools/pypi/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "msgpack >=1.0.2",
-    "posix_ipc >=1.0.5",
+    "posix_ipc >=1.1.1",
 ]
 keywords = ["motion control", "real time", "robotics"]
 

--- a/tools/workspace/pip_vulp/requirements_lock.txt
+++ b/tools/workspace/pip_vulp/requirements_lock.txt
@@ -1,3 +1,3 @@
 msgpack==1.0.2
-posix_ipc==1.0.5
+posix_ipc==1.1.1
 setuptools==67.4.0


### PR DESCRIPTION
Fixes the architecture error (i.e. ARM vs x86-64) for `posix_ipc` on macOS.