### PR TITLE
[feature] Portable Keyboard source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ## [1.3.0] - 2023/07/24
 
 ### Added
-- New portable Keyboard observer
+- Portable and SSH-compatible Keyboard source
 - Support macOS operating systems (with help from @boragokbakan)
 - Virtual destructor to the main ``Interface`` class
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ## [1.3.0] - 2023/07/24
 
 ### Added
-
+- New portable Keyboard observer
 - Support macOS operating systems (with help from @boragokbakan)
 - Virtual destructor to the main ``Interface`` class
 

--- a/observation/sources/BUILD
+++ b/observation/sources/BUILD
@@ -45,7 +45,7 @@ cc_library(
 cc_library(
     name = "sources",
     deps =  select({
-        "@//:linux": [":joystick", ":cpu_temperature, ":keyboard"],
+        "@//:linux": [":joystick", ":cpu_temperature", ":keyboard"],
         "@//conditions:default": [":cpu_temperature", ":keyboard"],
     }),
 )

--- a/observation/sources/BUILD
+++ b/observation/sources/BUILD
@@ -33,6 +33,16 @@ cc_library(
 )
 
 cc_library(
+    name = "keyboard",
+    hdrs = ["Keyboard.h"],
+    srcs = ["Keyboard.cpp"],
+    deps = [
+        "//observation:source",
+    ],
+    include_prefix = "vulp/observation/sources",
+)
+
+cc_library(
     name = "sources",
     deps =  select({
         "@//:linux": [":joystick", ":cpu_temperature"],

--- a/observation/sources/BUILD
+++ b/observation/sources/BUILD
@@ -45,8 +45,8 @@ cc_library(
 cc_library(
     name = "sources",
     deps =  select({
-        "@//:linux": [":joystick", ":cpu_temperature"],
-        "@//conditions:default": [":cpu_temperature"],
+        "@//:linux": [":joystick", ":cpu_temperature, ":keyboard"],
+        "@//conditions:default": [":cpu_temperature", ":keyboard"],
     }),
 )
 

--- a/observation/sources/Joystick.cpp
+++ b/observation/sources/Joystick.cpp
@@ -18,10 +18,11 @@
 
 namespace vulp::observation::sources {
 
-Joystick::Joystick() {
-  fd_ = ::open("/dev/input/js0", O_RDONLY | O_NONBLOCK);
+Joystick::Joystick(const std::string& device_path) {
+  fd_ = ::open(device_path.c_str(), O_RDONLY | O_NONBLOCK);
   if (fd_ < 0) {
-    spdlog::warn("Joystick observation disabled: no joystick found");
+    spdlog::warn("[Joystick] Observer disabled: no joystick found at {}",
+                 device_path);
   }
 }
 

--- a/observation/sources/Joystick.h
+++ b/observation/sources/Joystick.h
@@ -41,9 +41,9 @@ class Joystick : public Source {
  public:
   /*! Open the device file.
    *
-   * \note Use \ref present to check if the joystick was opened successfully.
+   * \param[in] device_path Path to the joystick device file.
    */
-  Joystick();
+  Joystick(const std::string& device_path = "/dev/input/js0");
 
   //! Close device file.
   ~Joystick() override;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -42,25 +42,7 @@ int Keyboard::read_event() {
         if(read_bytes != bytes){
             throw std::runtime_error("All bytes could not be read from the standard input!");
         }
-        /*
-        printf("We read %d/%d bytes \n", (int)read_bytes, bytes);
-        for(int i = 0; i < read_bytes; i++){
-            printf("0x%x [%d] ", buf_[i], buf_[i]);
-        }
-        printf("\n");
         
-        if(read_bytes >= 1){
-            printf("Arrow casting: ");
-            key key = map_char_to_key(buf_);
-            printf("%d \n", key);
-        }
-        
-        printf("\n");
-        
-        if(read_bytes < 0){
-            printf("Errno: %d \n", errno);
-        }
-        */
         return 1;
     }
     
@@ -101,10 +83,6 @@ Keyboard::key Keyboard::map_char_to_key(unsigned char *buf){
                 return key::D;
             case key::X:
                 return key::X;
-            case key::ESC:
-                return key::ESC;
-            case key::SPACE:
-                return key::SPACE;
         }
     }
     return key::UNKNOWN;
@@ -116,7 +94,17 @@ void Keyboard::write(Dictionary& observation) {
 
   auto& output = observation(prefix());
   output("key_pressed") = key_pressed;
-  output("key_code") = key_code;
+  output("up_arrow") = key_code == key::UP;
+  output("down_arrow") = key_code == key::DOWN;
+  output("left_arrow") = key_code == key::LEFT;
+  output("right_arrow") = key_code == key::RIGHT;
+  output("W") = key_code == key::W;
+  output("A") = key_code == key::A;
+  output("S") = key_code == key::S;
+  output("D") = key_code == key::D;
+  output("X") = key_code == key::X;
+  output("unknown_key") = key_code == key::UNKNOWN;
+
 }
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -49,12 +49,9 @@ bool Keyboard::read_event() {
         ::read(STDIN_FILENO, &buf_, bytes_to_read);
       } while (bytes_available);
     }
+    return 1;
   }
-
-  return 1;
-}
-
-return 0;
+  return 0;
 }
 
 Key Keyboard::map_char_to_key(unsigned char* buf) {

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -43,8 +43,7 @@ int Keyboard::read_event() {
     
     // Read if that's the case!
     if(bytes){
-        printf("Bytes to be read: %ld\n", bytes);
-        long read_bytes = ::read(STDIN_FILENO, &buf_, bytes);
+        long read_bytes = ::read(STDIN_FILENO, &buf_, min(bytes, MAX_KEY_BYTES));
         
         if(read_bytes != bytes){
             throw std::runtime_error("All bytes could not be read from the standard input!");

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -38,11 +38,13 @@ bool Keyboard::read_event() {
 
   if (bytes_available) {
     int bytes_to_read = std::min(bytes_available, (ssize_t)kMaxKeyBytes);
-    int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)bytes_to_read);
+    int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)kMaxKeyBytes);
 
-    if (bytes_read < bytes_to_read) {
+    if (bytes_read < bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
-      ::fflush(stdin);
+      // Clear the input buffer
+      fseek(stdin, 0, SEEK_END);
+      fpurge(stdin);
     }
 
     return 1;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -37,14 +37,14 @@ bool Keyboard::read_event() {
   ioctl(STDIN_FILENO, FIONREAD, &bytes_available);
 
   if (bytes_available) {
-    int bytes_to_read = std::min(bytes_available, (ssize_t)kMaxKeyBytes);
-    int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)kMaxKeyBytes);
+    ssize_t bytes_to_read = std::min(bytes_available, (ssize_t)kMaxKeyBytes);
+    ssize_t bytes_read = std::read(STDIN_FILENO, &buf_, bytes_to_read);
 
     if (bytes_read < bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
       // Clear the input buffer
-      fseek(stdin, 0, SEEK_END);
-      fpurge(stdin);
+      std::fseek(stdin, 0, SEEK_END);
+      std::fpurge(stdin);
     }
 
     return 1;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -105,13 +105,13 @@ void Keyboard::write(Dictionary& observation) {
   if (elapsed_ms >= KEY_POLLING_INTERVAL_MS) {
     key_pressed_ = read_event();
 
-    if (key_pressed_){
+    if (key_pressed_) {
       key_code_ = map_char_to_key(buf_);
-    }else{
+    } else {
       key_code_ = key::UNKNOWN;
     }
 
-    if(key_pressed_ && key_code_ == key::UNKNOWN) {
+    if (key_pressed_ && key_code_ == key::UNKNOWN) {
       key_pressed_ = false;
     }
   }

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -37,7 +37,8 @@ bool Keyboard::read_event() {
   ioctl(STDIN_FILENO, FIONREAD, &bytes_available);
 
   if (bytes_available) {
-    int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)bytes_available);
+    int bytes_to_read = std::min(bytes_available, (ssize_t)kMaxKeyBytes);
+    int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)bytes_to_read);
 
     // DEBUG
     printf("Read %d/%d bytes from stdin:", bytes_read, bytes_available);
@@ -47,10 +48,9 @@ bool Keyboard::read_event() {
     printf("\n");
     Key mapped_key = map_char_to_key(buf_);
     printf("Mapped key: %d\n", mapped_key);
-    printf("Key pressed: %d\n", key_pressed_);
     printf("\n\n\n");
 
-    if (bytes_read != bytes_available) {
+    if (bytes_read < bytes_to_read) {
       spdlog::warn("All bytes could not be read from the standard input!");
       ::fflush(stdin);
     }

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -116,10 +116,10 @@ void Keyboard::write(Dictionary& observation) {
 
   auto& output = observation(prefix());
   output("key_pressed") = key_pressed_;
-  output("up_arrow") = key_code_ == key::UP;
-  output("down_arrow") = key_code_ == key::DOWN;
-  output("left_arrow") = key_code_ == key::LEFT;
-  output("right_arrow") = key_code_ == key::RIGHT;
+  output("UP") = key_code_ == key::UP;
+  output("DOWN") = key_code_ == key::DOWN;
+  output("LEFT") = key_code_ == key::LEFT;
+  output("RIGHT") = key_code_ == key::RIGHT;
   output("W") = key_code_ == key::W;
   output("A") = key_code_ == key::A;
   output("S") = key_code_ == key::S;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -105,13 +105,15 @@ void Keyboard::write(Dictionary& observation) {
   if (elapsed_ms >= KEY_POLLING_INTERVAL_MS) {
     key_pressed_ = read_event();
 
-    if (key_pressed_)
+    if (key_pressed_){
       key_code_ = map_char_to_key(buf_);
-    else  // If no key is pressed, set the key code to unknown to avoid stale
-          // data
+    }else{
       key_code_ = key::UNKNOWN;
+    }
 
-    last_key_poll_time_ = system_clock::now();
+    if(key_pressed_ && key_code_ == key::UNKNOWN) {
+      key_pressed_ = false;
+    }
   }
 
   auto& output = observation(prefix());

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -101,7 +101,12 @@ void Keyboard::write(Dictionary& observation) {
 
   if (elapsed_ms >= KEY_POLLING_INTERVAL_MS) {
       key_pressed_ = read_event();
-      key_code_ = map_char_to_key(buf_);
+
+      if (key_pressed_) 
+        key_code_ = map_char_to_key(buf_);
+      else 
+        key_code_ = key::UNKNOWN;
+
       last_key_poll_time_ = ::system_clock::now();
   }else{
         printf("Elapsed time: %ld\n", elapsed_ms);
@@ -118,7 +123,6 @@ void Keyboard::write(Dictionary& observation) {
   output("S") = key_code_ == key::S;
   output("D") = key_code_ == key::D;
   output("X") = key_code_ == key::X;
-  output("unknown_key") = key_code_ == key::UNKNOWN;
 }
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -119,6 +119,7 @@ void Keyboard::write(Dictionary& observation) {
   output("s") = key_code_ == Key::S;
   output("d") = key_code_ == Key::D;
   output("x") = key_code_ == Key::X;
+  output("unknown") = key_code_ == Key::UNKNOWN;
 }
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -108,8 +108,6 @@ void Keyboard::write(Dictionary& observation) {
         key_code_ = key::UNKNOWN;
 
       last_key_poll_time_ = ::system_clock::now();
-  }else{
-        printf("Elapsed time: %ld\n", elapsed_ms);
   }
 
   auto& output = observation(prefix());

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -40,16 +40,6 @@ bool Keyboard::read_event() {
     int bytes_to_read = std::min(bytes_available, (ssize_t)kMaxKeyBytes);
     int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)bytes_to_read);
 
-    // DEBUG
-    printf("Read %d/%d bytes from stdin:", bytes_read, bytes_available);
-    for (int i = 0; i < bytes_read; i++) {
-      printf(" %d [%02x]", buf_[i], buf_[i]);
-    }
-    printf("\n");
-    Key mapped_key = map_char_to_key(buf_);
-    printf("Mapped key: %d\n", mapped_key);
-    printf("\n\n\n");
-
     if (bytes_read < bytes_to_read) {
       spdlog::warn("All bytes could not be read from the standard input!");
       ::fflush(stdin);
@@ -84,15 +74,15 @@ Key Keyboard::map_char_to_key(unsigned char* buf) {
   // We treat any printable ASCII as a single key code
   if (is_printable_ascii(buf[0])) {
     switch (buf[0]) {
-      case 87: // 0x57
+      case 87:  // 0x57
         return Key::W;
-      case 65: // 0x41
+      case 65:  // 0x41
         return Key::A;
-      case 83: // 0x53
+      case 83:  // 0x53
         return Key::S;
-      case 68: // 0x44
+      case 68:  // 0x44
         return Key::D;
-      case 88: // 0x58
+      case 88:  // 0x58
         return Key::X;
     }
   }

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -47,8 +47,7 @@ int Keyboard::read_event() {
     int bytes_read = ::read(STDIN_FILENO, &buf_, MAX_KEY_BYTES);
 
     if (bytes_read != bytes_available) {
-      throw std::runtime_error(
-          "All bytes could not be read from the standard input!");
+      spdlog::warn("All bytes could not be read from the standard input!");
     }
 
     return 1;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -65,7 +65,7 @@ int Keyboard::read_event() {
 
 Keyboard::key Keyboard::map_char_to_key(unsigned char *buf){
     // Check for 3-byte characters (i.e. arrows)
-    if(!memcmp(buf_, (unsigned char[])DOWN_BYTES, MAX_KEY_BYTES)){
+    if(memcmp(buf_, (unsigned char[])DOWN_BYTES, MAX_KEY_BYTES)){
         return key::DOWN;
     }
     if(!memcmp(buf_, (unsigned char[])UP_BYTES, MAX_KEY_BYTES)){
@@ -77,6 +77,8 @@ Keyboard::key Keyboard::map_char_to_key(unsigned char *buf){
     if(!memcmp(buf_, (unsigned char[])RIGHT_BYTES, MAX_KEY_BYTES)){
         return key::RIGHT;
     }
+
+    printf("Not an arrow!\n");
     
     // If the first byte corresponds to a lowercase ASCII alphabetic
     if(is_lowercase_alpha(buf[0])){

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -40,11 +40,15 @@ bool Keyboard::read_event() {
     int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)bytes_available);
 
     // DEBUG
-    printf("Read %d/%d bytes from stdin: ", bytes_read, bytes_available);
+    printf("Read %d/%d bytes from stdin:", bytes_read, bytes_available);
     for (int i = 0; i < bytes_read; i++) {
-      printf("%d [%02x]", buf_[i], buf_[i]);
+      printf(" %d [%02x]", buf_[i], buf_[i]);
     }
     printf("\n");
+    Key mapped_key = map_char_to_key(buf_);
+    printf("Mapped key: %d\n", mapped_key);
+    printf("Key pressed: %d\n", key_pressed_);
+    printf("\n\n\n");
 
     if (bytes_read != bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -43,7 +43,7 @@ int Keyboard::read_event() {
     
     // Read if that's the case!
     if(bytes){
-        long read_bytes = ::read(STDIN_FILENO, &buf_, min(bytes, MAX_KEY_BYTES));
+        long read_bytes = ::read(STDIN_FILENO, &buf_, std::min((int)bytes, MAX_KEY_BYTES));
         
         if(read_bytes != bytes){
             throw std::runtime_error("All bytes could not be read from the standard input!");

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -43,9 +43,10 @@ int Keyboard::read_event() {
     
     // Read if that's the case!
     if(bytes){
-        long read_bytes = ::read(STDIN_FILENO, &buf_, std::min((int)bytes, MAX_KEY_BYTES));
+        long bytes_to_read = std::min((int)bytes, MAX_KEY_BYTES);
+        long read_bytes = ::read(STDIN_FILENO, &buf_, bytes_to_read);
         
-        if(read_bytes != bytes){
+        if(read_bytes != bytes_to_read){
             throw std::runtime_error("All bytes could not be read from the standard input!");
         }
         

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -58,16 +58,16 @@ int Keyboard::read_event() {
 
 Keyboard::key Keyboard::map_char_to_key(unsigned char* buf) {
   // Check for 3-byte characters (i.e. arrows)
-  if (!memcmp(buf_, (unsigned char[])DOWN_BYTES, MAX_KEY_BYTES)) {
+  if (!memcmp(buf_, DOWN_BYTES, MAX_KEY_BYTES)) {
     return key::DOWN;
   }
-  if (!memcmp(buf_, (unsigned char[])UP_BYTES, MAX_KEY_BYTES)) {
+  if (!memcmp(buf_, UP_BYTES, MAX_KEY_BYTES)) {
     return key::UP;
   }
-  if (!memcmp(buf_, (unsigned char[])LEFT_BYTES, MAX_KEY_BYTES)) {
+  if (!memcmp(buf_, LEFT_BYTES, MAX_KEY_BYTES)) {
     return key::LEFT;
   }
-  if (!memcmp(buf_, (unsigned char[])RIGHT_BYTES, MAX_KEY_BYTES)) {
+  if (!memcmp(buf_, RIGHT_BYTES, MAX_KEY_BYTES)) {
     return key::RIGHT;
   }
 

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Stéphane Caron
+ * Copyright 2023 Inria
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -33,10 +33,6 @@ Keyboard::Keyboard() {
       system_clock::now() - milliseconds(KEY_POLLING_INTERVAL_MS);
 }
 
-Keyboard::~Keyboard() {
-  // Destructor
-}
-
 int Keyboard::read_event() {
   // Check if there are bytes to be read from the STDIN
   ssize_t bytes_available = 0;
@@ -49,6 +45,9 @@ int Keyboard::read_event() {
     if (bytes_read != bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
     }
+
+    // Flush the standard input buffer, in case there are stale commands
+    ::fflush(stdin);
 
     return 1;
   }

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -102,7 +102,7 @@ void Keyboard::write(Dictionary& observation) {
     if (key_pressed_) {
       key_code_ = map_char_to_key(buf_);
     } else {
-      key_code_ = Key::UNKNOWN;
+      key_code_ = Key::NONE;
     }
 
     last_key_poll_time_ = system_clock::now();
@@ -119,7 +119,7 @@ void Keyboard::write(Dictionary& observation) {
   output("s") = key_code_ == Key::S;
   output("d") = key_code_ == Key::D;
   output("x") = key_code_ == Key::X;
-  output("unknown") = key_code_ == Key::UNKNOWN && key_pressed_;
+  output("unknown") = key_code_ == Key::UNKNOWN;
 }
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -38,13 +38,13 @@ bool Keyboard::read_event() {
 
   if (bytes_available) {
     ssize_t bytes_to_read = std::min(bytes_available, (ssize_t)kMaxKeyBytes);
-    ssize_t bytes_read = std::read(STDIN_FILENO, &buf_, bytes_to_read);
+    ssize_t bytes_read = ::read(STDIN_FILENO, &buf_, bytes_to_read);
 
     if (bytes_read < bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
       // Clear the input buffer
-      std::fseek(stdin, 0, SEEK_END);
-      std::fpurge(stdin);
+      ::fseek(stdin, 0, SEEK_END);
+      ::fpurge(stdin);
     }
 
     return 1;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -65,10 +65,14 @@ int Keyboard::read_event() {
 
 Keyboard::key Keyboard::map_char_to_key(unsigned char *buf){
     // Check for 3-byte characters (i.e. arrows)
-    if(memcmp(buf_, (unsigned char[])DOWN_BYTES, MAX_KEY_BYTES)){
+    if(!memcmp(buf_, (unsigned char[])DOWN_BYTES, MAX_KEY_BYTES)){
+        printf("\n\nDOWN arrow!\n\n");
         return key::DOWN;
+    }else{
+        printf("\n\nNOT down arrow!\n\n");
     }
     if(!memcmp(buf_, (unsigned char[])UP_BYTES, MAX_KEY_BYTES)){
+        printf("\n\nUP arrow!\n\n");
         return key::UP;
     }
     if(!memcmp(buf_, (unsigned char[])LEFT_BYTES, MAX_KEY_BYTES)){

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -50,13 +50,6 @@ int Keyboard::read_event() {
             throw std::runtime_error("All bytes could not be read from the standard input!");
         }
         
-        // Print the read bytes in hexadecimal from the buffer
-        printf("Read %ld bytes: ", read_bytes);
-        for(int i = 0; i < read_bytes; i++){
-            printf("%02X ", buf_[i]);
-        }
-        printf("\n");
-
         return 1;
     }
     
@@ -69,7 +62,16 @@ Keyboard::key Keyboard::map_char_to_key(unsigned char *buf){
         printf("\n\nDOWN arrow!\n\n");
         return key::DOWN;
     }else{
+        // Print the read bytes in hexadecimal from the buffer
         printf("\n\nNOT down arrow!\n\n");
+
+        printf("Read %ld bytes: ", MAX_KEY_BYTES);
+        for(int i = 0; i < MAX_KEY_BYTES; i++){
+            printf("%02X ", buf_[i]);
+        }
+        printf("\n");
+
+
     }
     if(!memcmp(buf_, (unsigned char[])UP_BYTES, MAX_KEY_BYTES)){
         printf("\n\nUP arrow!\n\n");
@@ -82,7 +84,7 @@ Keyboard::key Keyboard::map_char_to_key(unsigned char *buf){
         return key::RIGHT;
     }
 
-    printf("Not an arrow!\n");
+    printf("\n\n\n\nNot an arrow!\n\n\n\n");
     
     // If the first byte corresponds to a lowercase ASCII alphabetic
     if(is_lowercase_alpha(buf[0])){

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -43,13 +43,18 @@ bool Keyboard::read_event() {
     if (bytes_read < bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
       // Skip the remaining bytes
-      ::read(STDIN_FILENO, nullptr, bytes_available - bytes_read);
+      do {
+        ioctl(STDIN_FILENO, FIONREAD, &bytes_available);
+        bytes_to_read = std::min(bytes_available, (ssize_t)kMaxKeyBytes);
+        ::read(STDIN_FILENO, &buf_, bytes_to_read);
+      } while (bytes_available);
     }
-
-    return 1;
   }
 
-  return 0;
+  return 1;
+}
+
+return 0;
 }
 
 Key Keyboard::map_char_to_key(unsigned char* buf) {

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -38,11 +38,9 @@ Keyboard::~Keyboard() {
 }
 
 int Keyboard::read_event() {
-  // Check if there are bytes to be read from the STDIN
   ssize_t bytes_available = 0;
   ioctl(STDIN_FILENO, FIONREAD, &bytes_available);
 
-  // Read if that's the case!
   if (bytes_available) {
     int bytes_read = ::read(STDIN_FILENO, &buf_, MAX_KEY_BYTES);
 

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -43,6 +43,7 @@ int Keyboard::read_event() {
     
     // Read if that's the case!
     if(bytes){
+        printf("Bytes to be read: %ld\n", bytes);
         long read_bytes = ::read(STDIN_FILENO, &buf_, bytes);
         
         if(read_bytes != bytes){

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -36,7 +36,7 @@ bool Keyboard::read_event() {
   ssize_t bytes_available = 0;
   ioctl(STDIN_FILENO, FIONREAD, &bytes_available);
 
-  if (bytes_available){
+  if (bytes_available) {
     int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)bytes_available);
 
     if (bytes_read != bytes_available) {
@@ -104,7 +104,6 @@ void Keyboard::write(Dictionary& observation) {
     }
 
     last_key_poll_time_ = system_clock::now();
-
   }
 
   auto& output = observation(prefix());

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -43,8 +43,8 @@ bool Keyboard::read_event() {
     if (bytes_read < bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
       // Clear the input buffer
-      ::fseek(stdin, 0, SEEK_END);
-      ::fpurge(stdin);
+      fseek(stdin, 0, SEEK_END);
+      fpurge(stdin);
     }
 
     return 1;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Stéphane Caron
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vulp/observation/sources/Keyboard.h"
+
+namespace vulp::observation::sources {
+Keyboard::Keyboard() {
+  // Constructor
+  termios term;
+  tcgetattr(STDIN_FILENO, &term);
+  term.c_lflag &= ~ICANON;
+  tcsetattr(STDIN_FILENO, TCSANOW, &term);
+  setbuf(stdin, NULL);
+}
+
+Keyboard::~Keyboard() {
+  // Destructor
+}
+
+int Keyboard::read_event() {
+    // Check if there are bytes to be read from the STDIN
+    ssize_t bytes = 0;
+    ioctl(STDIN_FILENO, FIONREAD, &bytes);
+    
+    // Read if that's the case!
+    if(bytes){
+        long read_bytes = ::read(STDIN_FILENO, &buf_, bytes);
+        
+        if(read_bytes != bytes){
+            throw std::runtime_error("All bytes could not be read from the standard input!");
+        }
+        /*
+        printf("We read %d/%d bytes \n", (int)read_bytes, bytes);
+        for(int i = 0; i < read_bytes; i++){
+            printf("0x%x [%d] ", buf_[i], buf_[i]);
+        }
+        printf("\n");
+        
+        if(read_bytes >= 1){
+            printf("Arrow casting: ");
+            key key = map_char_to_key(buf_);
+            printf("%d \n", key);
+        }
+        
+        printf("\n");
+        
+        if(read_bytes < 0){
+            printf("Errno: %d \n", errno);
+        }
+        */
+        return 1;
+    }
+    
+    return 0;
+}
+
+Keyboard::key Keyboard::map_char_to_key(unsigned char *buf){
+    // Check for 3-byte characters (i.e. arrows)
+    if(!memcmp(buf_, (unsigned char[])DOWN_BYTES, MAX_KEY_BYTES)){
+        return key::DOWN;
+    }
+    if(!memcmp(buf_, (unsigned char[])UP_BYTES, MAX_KEY_BYTES)){
+        return key::UP;
+    }
+    if(!memcmp(buf_, (unsigned char[])LEFT_BYTES, MAX_KEY_BYTES)){
+        return key::LEFT;
+    }
+    if(!memcmp(buf_, (unsigned char[])RIGHT_BYTES, MAX_KEY_BYTES)){
+        return key::RIGHT;
+    }
+    
+    // If the first byte corresponds to a lowercase ASCII alphabetic
+    if(is_lowercase_alpha(buf[0])){
+        buf[0] -= 32; // Map to uppercase equivalent;
+    }
+    
+    // We treat any printable ASCII as a single key code
+    if(is_printable_ascii(buf[0])){
+        switch (buf[0])
+        {
+            case key::W:
+                return key::W;
+            case key::A:
+                return key::A;
+            case key::S:
+                return key::S;
+            case key::D:
+                return key::D;
+            case key::X:
+                return key::X;
+            case key::ESC:
+                return key::ESC;
+            case key::SPACE:
+                return key::SPACE;
+        }
+    }
+    return key::UNKNOWN;
+}
+
+void Keyboard::write(Dictionary& observation) {
+  bool key_pressed = read_event();
+  key key_code = map_char_to_key(buf_);
+
+  auto& output = observation(prefix());
+  output("key_pressed") = key_pressed;
+  output("key_code") = key_code;
+}
+
+}  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -39,6 +39,13 @@ bool Keyboard::read_event() {
   if (bytes_available) {
     int bytes_read = ::read(STDIN_FILENO, &buf_, (ssize_t)bytes_available);
 
+    // DEBUG
+    printf("Read %d/%d bytes from stdin: ", bytes_read, bytes_available);
+    for (int i = 0; i < bytes_read; i++) {
+      printf("%d [%02x]", buf_[i], buf_[i]);
+    }
+    printf("\n");
+
     if (bytes_read != bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
       ::fflush(stdin);
@@ -73,15 +80,15 @@ Key Keyboard::map_char_to_key(unsigned char* buf) {
   // We treat any printable ASCII as a single key code
   if (is_printable_ascii(buf[0])) {
     switch (buf[0]) {
-      case 87:
+      case 87: // 0x57
         return Key::W;
-      case 65:
+      case 65: // 0x41
         return Key::A;
-      case 83:
+      case 83: // 0x53
         return Key::S;
-      case 68:
+      case 68: // 0x44
         return Key::D;
-      case 88:
+      case 88: // 0x58
         return Key::X;
     }
   }

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -33,6 +33,10 @@ Keyboard::Keyboard() {
       system_clock::now() - milliseconds(KEY_POLLING_INTERVAL_MS);
 }
 
+Keyboard::~Keyboard() {
+  // Destructor
+}
+
 int Keyboard::read_event() {
   // Check if there are bytes to be read from the STDIN
   ssize_t bytes_available = 0;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -42,9 +42,8 @@ bool Keyboard::read_event() {
 
     if (bytes_read < bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
-      // Clear the input buffer
+      // Skip the remaining bytes
       fseek(stdin, 0, SEEK_END);
-      fpurge(stdin);
     }
 
     return 1;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -42,7 +42,6 @@ bool Keyboard::read_event() {
     ssize_t bytes_read = ::read(STDIN_FILENO, &buf_, bytes_to_read);
 
     if (bytes_read < bytes_available) {
-      spdlog::warn("All bytes could not be read from the standard input!");
       // Skip the remaining bytes
       do {
         unsigned char garbage[bytes_available - bytes_read];

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -103,6 +103,8 @@ void Keyboard::write(Dictionary& observation) {
       key_pressed_ = read_event();
       key_code_ = map_char_to_key(buf_);
       last_key_poll_time_ = ::system_clock::now();
+  }else{
+        printf("Elapsed time: %ld\n", elapsed_ms);
   }
 
   auto& output = observation(prefix());

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -50,6 +50,13 @@ int Keyboard::read_event() {
             throw std::runtime_error("All bytes could not be read from the standard input!");
         }
         
+        // Print the read bytes in hexadecimal from the buffer
+        printf("Read %ld bytes: ", read_bytes);
+        for(int i = 0; i < read_bytes; i++){
+            printf("%02X ", buf_[i]);
+        }
+        printf("\n");
+
         return 1;
     }
     

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -119,7 +119,7 @@ void Keyboard::write(Dictionary& observation) {
   output("s") = key_code_ == Key::S;
   output("d") = key_code_ == Key::D;
   output("x") = key_code_ == Key::X;
-  output("unknown") = key_code_ == Key::UNKNOWN;
+  output("unknown") = key_code_ == Key::UNKNOWN && key_pressed_;
 }
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -43,7 +43,7 @@ bool Keyboard::read_event() {
     if (bytes_read < bytes_available) {
       spdlog::warn("All bytes could not be read from the standard input!");
       // Skip the remaining bytes
-      fseek(stdin, 0, SEEK_END);
+      ::read(STDIN_FILENO, nullptr, bytes_available - bytes_read);
     }
 
     return 1;

--- a/observation/sources/Keyboard.cpp
+++ b/observation/sources/Keyboard.cpp
@@ -16,10 +16,6 @@
 
 #include "vulp/observation/sources/Keyboard.h"
 
-using std::chrono::duration_cast;
-using std::chrono::milliseconds;
-using std::chrono::system_clock;
-
 namespace vulp::observation::sources {
 Keyboard::Keyboard() {
   // Constructor

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -67,6 +67,7 @@ enum class Key {
   S,
   D,
   X,
+  NONE,    // No key pressed
   UNKNOWN  // Map everything else to this key
 };
 

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -33,7 +33,7 @@
 #define KEY_POLLING_INTERVAL_MS 100 // Polling interval in milliseconds
 
 // Byte sequences that encode arrow keys are platform specific
-#ifdef __APPLE__
+#ifndef __APPLE__
 #define _HEAD 0xEF, 0x9C
 #define UP_BYTES {_HEAD, 0x80}
 #define DOWN_BYTES {_HEAD, 0x81}

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -74,7 +74,6 @@ enum class Key {
   S = 83,
   D = 68,
   X = 88,
-  NONE = 254,      // No key pressed
   UNKNOWN = 255  // Map everything else to this key
 };
 
@@ -86,8 +85,8 @@ enum class Key {
 class Keyboard : public Source {
  public:
   /*! Constructor sets up the terminal in non-canonical mode where
-  * input is available immediately without waiting for a newline.
-  */
+   * input is available immediately without waiting for a newline.
+   */
   Keyboard();
 
   //! Destructor

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -38,7 +38,7 @@ using std::chrono::system_clock;
 constexpr size_t kMaxKeyBytes = 3;
 
 //! Polling interval in milliseconds
-constexpr size_t kPollingIntervalMS = 100;
+constexpr long kPollingIntervalMS = 100;
 
 // Byte sequences that encode arrow keys are platform specific
 #ifndef __APPLE__

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Stéphane Caron
+ * Copyright 2023 Inria
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -38,7 +38,7 @@ using std::chrono::system_clock;
 constexpr size_t kMaxKeyBytes = 3;
 
 //! Polling interval in milliseconds
-constexpr int64_t kPollingIntervalMS = 100;
+constexpr int64_t kPollingIntervalMS = 50;
 
 // Byte sequences that encode arrow keys are platform specific
 #ifndef __APPLE__

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -25,10 +25,12 @@
 #include <termios.h>
 #include <string.h>
 #include <iostream>
+#include <chrono>
 
 #include "vulp/observation/Source.h"
 
 #define MAX_KEY_BYTES 3 // Maximum number of bytes to encode a key
+#define KEY_POLLING_INTERVAL_MS 100 // Polling interval in milliseconds
 
 // Byte sequences that encode arrow keys are platform specific
 #ifdef __APPLE__
@@ -48,6 +50,8 @@
 #define is_lowercase_alpha(c) 0x61 <= c && c <= 0x7A // Checks if 'a' <= c <= 'z'
 #define is_uppercase_alpha(c) 0x41 <= c && c <= 0x5A // Checks if 'A' <= c <= 'Z'
 #define is_printable_ascii(c) 0x20 <= c && c <= 0x7F
+
+using namespace std::chrono;
 
 namespace vulp::observation::sources {
 
@@ -98,6 +102,12 @@ class Keyboard : public Source {
   key map_char_to_key(unsigned char * buf);
 
   unsigned char buf_[MAX_KEY_BYTES]; // Read ASCII and non-ASCII characters (e.g. arrows)
+
+  key key_code_; // Key code of the last key pressed
+  bool key_pressed_; // Whether the last key pressed is still pressed
+
+  // Last time a key was pressed in milliseconds
+  ::system_clock::time_point last_key_poll_time_;
 
 };
 

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -30,59 +30,71 @@
 
 #include "vulp/observation/Source.h"
 
-#define MAX_KEY_BYTES 3              // Maximum number of bytes to encode a key
-#define KEY_POLLING_INTERVAL_MS 100  // Polling interval in milliseconds
-
-// Byte sequences that encode arrow keys are platform specific
-#ifndef __APPLE__
-const unsigned char UP_BYTES[] = {0xEF, 0x9C, 0x80};
-const unsigned char DOWN_BYTES[] = {0xEF, 0x9C, 0x81};
-const unsigned char RIGHT_BYTES[] = {0xEF, 0x9C, 0x83};
-const unsigned char LEFT_BYTES[] = {0xEF, 0x9C, 0x82};
-#else
-const unsigned char UP_BYTES[] = {0x1B, 0x5B, 0x41};
-const unsigned char DOWN_BYTES[] = {0x1B, 0x5B, 0x42};
-const unsigned char RIGHT_BYTES[] = {0x1B, 0x5B, 0x43};
-const unsigned char LEFT_BYTES[] = {0x1B, 0x5B, 0x44};
-#endif
-
-#define is_lowercase_alpha(c) \
-  0x61 <= c&& c <= 0x7A  // Checks if 'a' <= c <= 'z'
-#define is_uppercase_alpha(c) \
-  0x41 <= c&& c <= 0x5A  // Checks if 'A' <= c <= 'Z'
-#define is_printable_ascii(c) 0x20 <= c&& c <= 0x7F
-
 using std::chrono::duration_cast;
 using std::chrono::milliseconds;
 using std::chrono::system_clock;
 
-namespace vulp::observation::sources {
+//! Maximum number of bytes to encode a key
+constexpr size_t kMaxKeyBytes = 3;
 
-/*! Source for a Keyboard controller.
- * *
- * \note This source reads from the standard input.
+//! Maximum number of bytes to read from STDIN
+constexpr size_t kMaxReadBytes = 10;
+
+//! Polling interval in milliseconds
+constexpr size_t kPollingIntervalMS = 100;
+
+// Byte sequences that encode arrow keys are platform specific
+#ifndef __APPLE__
+constexpr unsigned char UP_BYTES[] = {0xEF, 0x9C, 0x80};
+constexpr unsigned char DOWN_BYTES[] = {0xEF, 0x9C, 0x81};
+constexpr unsigned char RIGHT_BYTES[] = {0xEF, 0x9C, 0x83};
+constexpr unsigned char LEFT_BYTES[] = {0xEF, 0x9C, 0x82};
+#else
+constexpr unsigned char UP_BYTES[] = {0x1B, 0x5B, 0x41};
+constexpr unsigned char DOWN_BYTES[] = {0x1B, 0x5B, 0x42};
+constexpr unsigned char RIGHT_BYTES[] = {0x1B, 0x5B, 0x43};
+constexpr unsigned char LEFT_BYTES[] = {0x1B, 0x5B, 0x44};
+#endif
+
+inline bool is_lowercase_alpha(unsigned char c) {
+  return 0x61 <= c && c <= 0x7A;
+}
+inline bool is_uppercase_alpha(unsigned char c) {
+  return 0x41 <= c && c <= 0x5A;
+}
+inline bool is_printable_ascii(unsigned char c) {
+  return 0x20 <= c && c <= 0x7F;
+}
+
+namespace vulp::observation::sources {
+enum class Key {
+  UP = 0,
+  DOWN = 1,
+  LEFT = 2,
+  RIGHT = 3,
+  W = 87,
+  A = 65,
+  S = 83,
+  D = 68,
+  X = 88,
+  NONE = 254,      // No key pressed
+  UNKNOWN = 255  // Map everything else to this key
+};
+
+/*! Source for reading Keyboard inputs.
+ *
+ * \note This source reads from the standard input, and does
+ * not listen to Keyboard events. It can only read one key at a time.
  */
 class Keyboard : public Source {
  public:
+  /*! Constructor sets up the terminal in non-canonical mode where
+  * input is available immediately without waiting for a newline.
+  */
   Keyboard();
 
+  //! Destructor
   ~Keyboard() override;
-
-  enum key {
-    // Directional keys (arrows)
-    UP = 0,
-    DOWN = 1,
-    LEFT = 2,
-    RIGHT = 3,
-    // Single char keys (alphabetical)
-    W = 87,
-    A = 65,
-    S = 83,
-    D = 68,
-    X = 88,
-    // Unknown key
-    UNKNOWN = 255  // Map everything else to this key
-  };
 
   //! Prefix of output in the observation dictionary.
   inline std::string prefix() const noexcept final { return "keyboard"; }
@@ -94,18 +106,33 @@ class Keyboard : public Source {
   void write(Dictionary& output) final;
 
  private:
-  //! Read next joystick event from the device file.
-  int read_event();
+  //! Read the next key event from STDIN.
+  Key read_event();
 
-  key map_char_to_key(unsigned char* buf);
+  /*! Map a character to a key code.
+   *
+   * \param[in] buf Buffer containing the character.
+   * \return Key value
+   */
+  Key map_char_to_key(unsigned char* buf);
 
-  unsigned char
-      buf_[MAX_KEY_BYTES];  // Read ASCII and non-ASCII characters (e.g. arrows)
+  /*! Shifts array elements one position to left.
+   *
+   * \param[in] buf Array to shift.
+   * \param[in] array_size Size of the array.
+   */
+  void shift_left(unsigned char* buf, size_t array_size);
 
-  key key_code_;      // Key code of the last key pressed
-  bool key_pressed_;  // Whether the last key pressed is still pressed
+  //! Buffer to store incoming bytes from STDIN
+  unsigned char buf_[kMaxKeyBytes];
 
-  // Last time a key was pressed in milliseconds
+  //! Key code of the last key pressed
+  Key key_code_;
+
+  //! Whether the last key pressed is still pressed
+  bool key_pressed_;
+
+  //! Last time a key was pressed in milliseconds
   system_clock::time_point last_key_poll_time_;
 };
 

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -65,16 +65,16 @@ inline bool is_printable_ascii(unsigned char c) {
 
 namespace vulp::observation::sources {
 enum class Key {
-  UP = 0,
-  DOWN = 1,
-  LEFT = 2,
-  RIGHT = 3,
-  W = 87,
-  A = 65,
-  S = 83,
-  D = 68,
-  X = 88,
-  UNKNOWN = 255  // Map everything else to this key
+  UP,
+  DOWN,
+  LEFT,
+  RIGHT,
+  W,
+  A,
+  S,
+  D,
+  X,
+  UNKNOWN  // Map everything else to this key
 };
 
 /*! Source for reading Keyboard inputs.

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -62,6 +62,10 @@
   0x41 <= c&& c <= 0x5A  // Checks if 'A' <= c <= 'Z'
 #define is_printable_ascii(c) 0x20 <= c&& c <= 0x7F
 
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::system_clock;
+
 namespace vulp::observation::sources {
 
 /*! Source for a Keyboard controller.
@@ -117,7 +121,7 @@ class Keyboard : public Source {
   bool key_pressed_;        // Whether the last key pressed is still pressed
 
   // Last time a key was pressed in milliseconds
-  ::system_clock::time_point last_key_poll_time_;
+  system_clock::time_point last_key_poll_time_;
 };
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -38,7 +38,7 @@ using std::chrono::system_clock;
 constexpr size_t kMaxKeyBytes = 3;
 
 //! Polling interval in milliseconds
-constexpr long kPollingIntervalMS = 100;
+constexpr int64_t kPollingIntervalMS = 100;
 
 // Byte sequences that encode arrow keys are platform specific
 #ifndef __APPLE__

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -72,14 +72,13 @@ class Keyboard : public Source {
     DOWN = 1,
     LEFT = 2,
     RIGHT = 3,
-    // Special keys
+    // Single char keys (alphabetical)
     W = 87,
     A = 65,
     S = 83,
     D = 68,
     X = 88,
-    SPACE = 32,
-    ESC = 27,
+    // Unknown key
     UNKNOWN = -1 // Map everything else to this key
   };
 
@@ -99,9 +98,6 @@ class Keyboard : public Source {
   key map_char_to_key(unsigned char * buf);
 
   unsigned char buf_[MAX_KEY_BYTES]; // Read ASCII and non-ASCII characters (e.g. arrows)
-  
-  // Key pressed
-  key pressed_;
 
 };
 

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -40,7 +40,7 @@ constexpr size_t kMaxKeyBytes = 3;
 //! Polling interval in milliseconds
 constexpr int64_t kPollingIntervalMS = 50;
 
-// Scan codes for arrow keys 
+// Scan codes for arrow keys
 constexpr unsigned char UP_BYTES[] = {0x1B, 0x5B, 0x41};
 constexpr unsigned char DOWN_BYTES[] = {0x1B, 0x5B, 0x42};
 constexpr unsigned char RIGHT_BYTES[] = {0x1B, 0x5B, 0x43};

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -83,7 +83,7 @@ class Keyboard : public Source {
     D = 68,
     X = 88,
     // Unknown key
-    UNKNOWN = -1 // Map everything else to this key
+    UNKNOWN = 255 // Map everything else to this key
   };
 
   //! Prefix of output in the observation dictionary.

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -37,9 +37,6 @@ using std::chrono::system_clock;
 //! Maximum number of bytes to encode a key
 constexpr size_t kMaxKeyBytes = 3;
 
-//! Maximum number of bytes to read from STDIN
-constexpr size_t kMaxReadBytes = 10;
-
 //! Polling interval in milliseconds
 constexpr size_t kPollingIntervalMS = 100;
 
@@ -107,7 +104,7 @@ class Keyboard : public Source {
 
  private:
   //! Read the next key event from STDIN.
-  Key read_event();
+  bool read_event();
 
   /*! Map a character to a key code.
    *
@@ -115,13 +112,6 @@ class Keyboard : public Source {
    * \return Key value
    */
   Key map_char_to_key(unsigned char* buf);
-
-  /*! Shifts array elements one position to left.
-   *
-   * \param[in] buf Array to shift.
-   * \param[in] array_size Size of the array.
-   */
-  void shift_left(unsigned char* buf, size_t array_size);
 
   //! Buffer to store incoming bytes from STDIN
   unsigned char buf_[kMaxKeyBytes];

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -18,40 +18,49 @@
 
 #include <fcntl.h>
 #include <stdio.h>
-#include <unistd.h>
-#include <sys/select.h>
-#include <sys/ioctl.h>
-#include <string>
-#include <termios.h>
 #include <string.h>
-#include <iostream>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <termios.h>
+#include <unistd.h>
+
 #include <chrono>
+#include <iostream>
+#include <string>
 
 #include "vulp/observation/Source.h"
 
-#define MAX_KEY_BYTES 3 // Maximum number of bytes to encode a key
-#define KEY_POLLING_INTERVAL_MS 100 // Polling interval in milliseconds
+#define MAX_KEY_BYTES 3              // Maximum number of bytes to encode a key
+#define KEY_POLLING_INTERVAL_MS 100  // Polling interval in milliseconds
 
 // Byte sequences that encode arrow keys are platform specific
 #ifndef __APPLE__
 #define _HEAD 0xEF, 0x9C
-#define UP_BYTES {_HEAD, 0x80}
-#define DOWN_BYTES {_HEAD, 0x81}
-#define RIGHT_BYTES {_HEAD, 0x83}
-#define LEFT_BYTES {_HEAD, 0x82}
+#define UP_BYTES \
+  { _HEAD, 0x80 }
+#define DOWN_BYTES \
+  { _HEAD, 0x81 }
+#define RIGHT_BYTES \
+  { _HEAD, 0x83 }
+#define LEFT_BYTES \
+  { _HEAD, 0x82 }
 #else
 #define _HEAD 0x1B, 0x5B
-#define UP_BYTES {_HEAD, 0x41}
-#define DOWN_BYTES {_HEAD, 0x42}
-#define RIGHT_BYTES {_HEAD, 0x43}
-#define LEFT_BYTES {_HEAD, 0x44}
+#define UP_BYTES \
+  { _HEAD, 0x41 }
+#define DOWN_BYTES \
+  { _HEAD, 0x42 }
+#define RIGHT_BYTES \
+  { _HEAD, 0x43 }
+#define LEFT_BYTES \
+  { _HEAD, 0x44 }
 #endif
 
-#define is_lowercase_alpha(c) 0x61 <= c && c <= 0x7A // Checks if 'a' <= c <= 'z'
-#define is_uppercase_alpha(c) 0x41 <= c && c <= 0x5A // Checks if 'A' <= c <= 'Z'
-#define is_printable_ascii(c) 0x20 <= c && c <= 0x7F
-
-using namespace std::chrono;
+#define is_lowercase_alpha(c) \
+  0x61 <= c&& c <= 0x7A  // Checks if 'a' <= c <= 'z'
+#define is_uppercase_alpha(c) \
+  0x41 <= c&& c <= 0x5A  // Checks if 'A' <= c <= 'Z'
+#define is_printable_ascii(c) 0x20 <= c&& c <= 0x7F
 
 namespace vulp::observation::sources {
 
@@ -83,7 +92,7 @@ class Keyboard : public Source {
     D = 68,
     X = 88,
     // Unknown key
-    UNKNOWN = 255 // Map everything else to this key
+    UNKNOWN = 255  // Map everything else to this key
   };
 
   //! Prefix of output in the observation dictionary.
@@ -98,17 +107,17 @@ class Keyboard : public Source {
  private:
   //! Read next joystick event from the device file.
   int read_event();
-  
-  key map_char_to_key(unsigned char * buf);
 
-  unsigned char buf_[MAX_KEY_BYTES]; // Read ASCII and non-ASCII characters (e.g. arrows)
+  key map_char_to_key(unsigned char* buf);
 
-  key key_code_; // Key code of the last key pressed
-  bool key_pressed_; // Whether the last key pressed is still pressed
+  unsigned char
+      buf_[MAX_KEY_BYTES];  // Read ASCII and non-ASCII characters (e.g. arrows)
+
+  key key_code_;            // Key code of the last key pressed
+  bool key_pressed_;        // Whether the last key pressed is still pressed
 
   // Last time a key was pressed in milliseconds
   ::system_clock::time_point last_key_poll_time_;
-
 };
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -35,25 +35,15 @@
 
 // Byte sequences that encode arrow keys are platform specific
 #ifndef __APPLE__
-#define _HEAD 0xEF, 0x9C
-#define UP_BYTES \
-  { _HEAD, 0x80 }
-#define DOWN_BYTES \
-  { _HEAD, 0x81 }
-#define RIGHT_BYTES \
-  { _HEAD, 0x83 }
-#define LEFT_BYTES \
-  { _HEAD, 0x82 }
+const unsigned char UP_BYTES[] = {0xEF, 0x9C, 0x80};
+const unsigned char DOWN_BYTES[] = {0xEF, 0x9C, 0x81};
+const unsigned char RIGHT_BYTES[] = {0xEF, 0x9C, 0x83};
+const unsigned char LEFT_BYTES[] = {0xEF, 0x9C, 0x82};
 #else
-#define _HEAD 0x1B, 0x5B
-#define UP_BYTES \
-  { _HEAD, 0x41 }
-#define DOWN_BYTES \
-  { _HEAD, 0x42 }
-#define RIGHT_BYTES \
-  { _HEAD, 0x43 }
-#define LEFT_BYTES \
-  { _HEAD, 0x44 }
+const unsigned char UP_BYTES[] = {0x1B, 0x5B, 0x41};
+const unsigned char DOWN_BYTES[] = {0x1B, 0x5B, 0x42};
+const unsigned char RIGHT_BYTES[] = {0x1B, 0x5B, 0x43};
+const unsigned char LEFT_BYTES[] = {0x1B, 0x5B, 0x44};
 #endif
 
 #define is_lowercase_alpha(c) \

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -40,18 +40,11 @@ constexpr size_t kMaxKeyBytes = 3;
 //! Polling interval in milliseconds
 constexpr int64_t kPollingIntervalMS = 50;
 
-// Byte sequences that encode arrow keys are platform specific
-#ifndef __APPLE__
-constexpr unsigned char UP_BYTES[] = {0xEF, 0x9C, 0x80};
-constexpr unsigned char DOWN_BYTES[] = {0xEF, 0x9C, 0x81};
-constexpr unsigned char RIGHT_BYTES[] = {0xEF, 0x9C, 0x83};
-constexpr unsigned char LEFT_BYTES[] = {0xEF, 0x9C, 0x82};
-#else
+// Scan codes for arrow keys 
 constexpr unsigned char UP_BYTES[] = {0x1B, 0x5B, 0x41};
 constexpr unsigned char DOWN_BYTES[] = {0x1B, 0x5B, 0x42};
 constexpr unsigned char RIGHT_BYTES[] = {0x1B, 0x5B, 0x43};
 constexpr unsigned char LEFT_BYTES[] = {0x1B, 0x5B, 0x44};
-#endif
 
 inline bool is_lowercase_alpha(unsigned char c) {
   return 0x61 <= c && c <= 0x7A;

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -107,8 +107,8 @@ class Keyboard : public Source {
   unsigned char
       buf_[MAX_KEY_BYTES];  // Read ASCII and non-ASCII characters (e.g. arrows)
 
-  key key_code_;            // Key code of the last key pressed
-  bool key_pressed_;        // Whether the last key pressed is still pressed
+  key key_code_;      // Key code of the last key pressed
+  bool key_pressed_;  // Whether the last key pressed is still pressed
 
   // Last time a key was pressed in milliseconds
   system_clock::time_point last_key_poll_time_;

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 Stéphane Caron
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/ioctl.h>
+#include <string>
+#include <termios.h>
+#include <string.h>
+#include <iostream>
+
+#include "vulp/observation/Source.h"
+
+#define MAX_KEY_BYTES 3 // Maximum number of bytes to encode a key
+
+// Byte sequences that encode arrow keys are platform specific
+#ifdef __APPLE__
+#define _HEAD 0xEF, 0x9C
+#define UP_BYTES {_HEAD, 0x80}
+#define DOWN_BYTES {_HEAD, 0x81}
+#define RIGHT_BYTES {_HEAD, 0x83}
+#define LEFT_BYTES {_HEAD, 0x82}
+#else
+#define _HEAD 0x1B, 0x5B
+#define UP_BYTES {_HEAD, 0x41}
+#define DOWN_BYTES {_HEAD, 0x42}
+#define RIGHT_BYTES {_HEAD, 0x43}
+#define LEFT_BYTES {_HEAD, 0x44}
+#endif
+
+#define is_lowercase_alpha(c) 0x61 <= c && c <= 0x7A // Checks if 'a' <= c <= 'z'
+#define is_uppercase_alpha(c) 0x41 <= c && c <= 0x5A // Checks if 'A' <= c <= 'Z'
+#define is_printable_ascii(c) 0x20 <= c && c <= 0x7F
+
+namespace vulp::observation::sources {
+
+/*! Source for a Keyboard controller.
+ * *
+ * \note This source reads from the standard input.
+ */
+class Keyboard : public Source {
+ public:
+  /*! Open the device file.
+   *
+   * \note Use \ref present to check if the joystick was opened successfully.
+   */
+  Keyboard();
+
+  //! Close device file.
+  ~Keyboard() override;
+
+  enum key {
+    // Directional keys (arrows)
+    UP = 0,
+    DOWN = 1,
+    LEFT = 2,
+    RIGHT = 3,
+    // Special keys
+    W = 87,
+    A = 65,
+    S = 83,
+    D = 68,
+    X = 88,
+    SPACE = 32,
+    ESC = 27,
+    UNKNOWN = -1 // Map everything else to this key
+  };
+
+  //! Prefix of output in the observation dictionary.
+  inline std::string prefix() const noexcept final { return "keyboard"; }
+
+  /*! Write output to a dictionary.
+   *
+   * \param[out] output Dictionary to write observations to.
+   */
+  void write(Dictionary& output) final;
+
+ private:
+  //! Read next joystick event from the device file.
+  int read_event();
+  
+  key map_char_to_key(unsigned char * buf);
+
+  unsigned char buf_[MAX_KEY_BYTES]; // Read ASCII and non-ASCII characters (e.g. arrows)
+  
+  // Key pressed
+  key pressed_;
+
+};
+
+}  // namespace vulp::observation::sources

--- a/observation/sources/Keyboard.h
+++ b/observation/sources/Keyboard.h
@@ -64,13 +64,8 @@ namespace vulp::observation::sources {
  */
 class Keyboard : public Source {
  public:
-  /*! Open the device file.
-   *
-   * \note Use \ref present to check if the joystick was opened successfully.
-   */
   Keyboard();
 
-  //! Close device file.
   ~Keyboard() override;
 
   enum key {

--- a/observation/sources/tests/JoystickTest.cpp
+++ b/observation/sources/tests/JoystickTest.cpp
@@ -84,4 +84,62 @@ TEST(Joystick, EmergencyStop) {
   ASSERT_THROW(joystick.write(observation), std::runtime_error);
 }
 
+TEST(Joystick, ReadAxes) {
+  std::ofstream file("jsX", std::ios::binary | std::ios::out);
+  Joystick joystick("jsX");
+
+  struct js_event event;
+  event.type = JS_EVENT_AXIS;
+  event.number = 0;
+  event.value = 10000;
+  file.write(reinterpret_cast<char*>(&event), sizeof(event));
+  file.flush();
+
+  Dictionary observation;
+  joystick.write(observation);
+  const auto& output = observation(joystick.prefix());
+  const Eigen::Vector2d& left_axis = output("left_axis");
+  ASSERT_LE(left_axis.x(), 0.4);
+  ASSERT_GE(left_axis.x(), 0.2);
+  ASSERT_DOUBLE_EQ(left_axis.y(), 0.0);
+
+  const std::vector<std::string> axes = {"left_axis", "right_axis", "pad_axis"};
+  for (uint8_t axis = 1; axis < 9; axis++) {
+    event.number = axis;
+    file.write(reinterpret_cast<char*>(&event), sizeof(event));
+    file.flush();
+    joystick.write(observation);
+    for (const std::string& axis : axes) {
+      const Eigen::Vector2d& axis_vector = output(axis);
+      ASSERT_GE(axis_vector.x(), 0.0);
+      ASSERT_GE(axis_vector.y(), 0.0);
+      ASSERT_LE(axis_vector.x(), 1.0);
+      ASSERT_LE(axis_vector.y(), 1.0);
+    }
+  }
+}
+
+TEST(Joystick, ReadTriggers) {
+  std::ofstream file("jsX", std::ios::binary | std::ios::out);
+  Joystick joystick("jsX");
+  const std::vector<std::string> triggers = {"left_trigger", "right_trigger"};
+  for (uint8_t axis = 1; axis < 9; axis++) {
+    struct js_event event;
+    event.type = JS_EVENT_AXIS;
+    event.number = axis;
+    event.value = 10000;
+    file.write(reinterpret_cast<char*>(&event), sizeof(event));
+    file.flush();
+
+    Dictionary observation;
+    joystick.write(observation);
+    for (const std::string& trigger : triggers) {
+      const auto& output = observation(joystick.prefix());
+      const double trigger_value = output(trigger);
+      ASSERT_GE(trigger_value, -1.0);
+      ASSERT_LE(trigger_value, 1.0);
+    }
+  }
+}
+
 }  // namespace vulp::observation::sources

--- a/observation/sources/tests/JoystickTest.cpp
+++ b/observation/sources/tests/JoystickTest.cpp
@@ -69,4 +69,19 @@ TEST(Joystick, ReadButtons) {
   }
 }
 
+TEST(Joystick, EmergencyStop) {
+  std::ofstream file("jsX", std::ios::binary | std::ios::out);
+  Joystick joystick("jsX");
+
+  struct js_event event;
+  event.type = JS_EVENT_BUTTON;
+  event.number = 1;
+  event.value = 1;
+  file.write(reinterpret_cast<char*>(&event), sizeof(event));
+  file.flush();
+
+  Dictionary observation;
+  ASSERT_THROW(joystick.write(observation), std::runtime_error);
+}
+
 }  // namespace vulp::observation::sources

--- a/observation/sources/tests/JoystickTest.cpp
+++ b/observation/sources/tests/JoystickTest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#include <linux/joystick.h>
+
+#include <fstream>
+
 #include "gtest/gtest.h"
 #include "vulp/observation/sources/Joystick.h"
 
@@ -21,6 +25,19 @@ namespace vulp::observation::sources {
 
 TEST(Joystick, WriteOnce) {
   Joystick joystick;
+  Dictionary observation;
+  ASSERT_NO_THROW(joystick.write(observation));
+}
+
+TEST(Joystick, UnknownEvent) {
+  std::ofstream file("jsX", std::ios::binary | std::ios::out);
+  Joystick joystick("jsX");
+
+  struct js_event event;
+  event.type = JS_EVENT_INIT;
+  file.write(reinterpret_cast<char*>(&event), sizeof(event));
+  file.flush();
+
   Dictionary observation;
   ASSERT_NO_THROW(joystick.write(observation));
 }

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -26,7 +26,7 @@ TEST(Keyboard, WriteOnce) {
   ASSERT_NO_THROW(keyboard.write(observation));
 }
 
-TEST(Keyboard, ReadButtons) {
+TEST(Keyboard, ReadAlphabetical) {
   // We cannot write directly to STDIN, so we'll redirect a file to it
   char *tmpfn = tmpnam(nullptr);
   std::ofstream tmpf(tmpfn);
@@ -76,7 +76,7 @@ TEST(Keyboard, ReadArrows) {
   ASSERT_FALSE(output.get<bool>("X"));
 }
 
-TEST(Keyboard, ReadNothing) {
+TEST(Keyboard, ReadEmptySTDIN) {
   Keyboard keyboard = Keyboard();
 
   Dictionary observation;

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -30,7 +30,7 @@ TEST(Keyboard, ReadAlphabetical) {
   // We cannot write directly to STDIN, so we'll redirect a file to it
   char* tmpfn = tmpnam(nullptr);
   std::ofstream tmpf(tmpfn);
-  tmpf << "A";  //(unsigned char[]){'A'};
+  tmpf << "A";
   tmpf.close();
 
   freopen(tmpfn, "r", stdin);

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -26,7 +26,7 @@ TEST(Keyboard, WriteOnce) {
   ASSERT_NO_THROW(keyboard.write(observation));
 }
 
-TEST(Joystick, ReadButtons) {
+TEST(Keyboard, ReadButtons) {
   // We cannot write directly to STDIN, so we'll redirect a file to it
   char *tmpfn = tmpnam(nullptr);
   std::ofstream tmpf(tmpfn);
@@ -49,7 +49,7 @@ TEST(Joystick, ReadButtons) {
   ASSERT_FALSE(output.get<bool>("X"));
 }
 
-TEST(Joystick, ReadArrows) {
+TEST(Keyboard, ReadArrows) {
   // We cannot write directly to STDIN, so we'll redirect a file to it
   char *tmpfn = tmpnam(nullptr);
   std::ofstream tmpf(tmpfn);
@@ -76,7 +76,7 @@ TEST(Joystick, ReadArrows) {
   ASSERT_FALSE(output.get<bool>("X"));
 }
 
-TEST(Joystick, ReadNothing) {
+TEST(Keyboard, ReadNothing) {
   Keyboard keyboard = Keyboard();
 
   Dictionary observation;

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -77,6 +77,8 @@ TEST(Keyboard, ReadArrows) {
 }
 
 TEST(Keyboard, ReadEmptySTDIN) {
+  fflush(stdin); // Clear STDIN
+
   Keyboard keyboard = Keyboard();
 
   Dictionary observation;

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -69,15 +69,15 @@ TEST(Keyboard, ReadArrows) {
 
   const auto& output = observation(keyboard.prefix());
   ASSERT_TRUE(output.get<bool>("key_pressed"));
-  ASSERT_TRUE(output.get<bool>("LEFT"));
-  ASSERT_FALSE(output.get<bool>("UP")); 
-  ASSERT_FALSE(output.get<bool>("DOWN"));
-  ASSERT_FALSE(output.get<bool>("RIGHT"));
-  ASSERT_FALSE(output.get<bool>("W"));
-  ASSERT_FALSE(output.get<bool>("A"));
-  ASSERT_FALSE(output.get<bool>("S"));
-  ASSERT_FALSE(output.get<bool>("D"));
-  ASSERT_FALSE(output.get<bool>("X"));
+  ASSERT_TRUE(output.get<bool>("left"));
+  ASSERT_FALSE(output.get<bool>("up")); 
+  ASSERT_FALSE(output.get<bool>("down"));
+  ASSERT_FALSE(output.get<bool>("right"));
+  ASSERT_FALSE(output.get<bool>("w"));
+  ASSERT_FALSE(output.get<bool>("a"));
+  ASSERT_FALSE(output.get<bool>("s"));
+  ASSERT_FALSE(output.get<bool>("d"));
+  ASSERT_FALSE(output.get<bool>("x"));
 }
 
 TEST(Keyboard, ReadEmptySTDIN) {
@@ -90,15 +90,15 @@ TEST(Keyboard, ReadEmptySTDIN) {
 
   const auto& output = observation(keyboard.prefix());
   ASSERT_FALSE(output.get<bool>("key_pressed"));
-  ASSERT_FALSE(output.get<bool>("LEFT"));
-  ASSERT_FALSE(output.get<bool>("UP")); 
-  ASSERT_FALSE(output.get<bool>("DOWN"));
-  ASSERT_FALSE(output.get<bool>("RIGHT"));
-  ASSERT_FALSE(output.get<bool>("W"));
-  ASSERT_FALSE(output.get<bool>("A"));
-  ASSERT_FALSE(output.get<bool>("S"));
-  ASSERT_FALSE(output.get<bool>("D"));
-  ASSERT_FALSE(output.get<bool>("X"));
+  ASSERT_FALSE(output.get<bool>("left"));
+  ASSERT_FALSE(output.get<bool>("up")); 
+  ASSERT_FALSE(output.get<bool>("down"));
+  ASSERT_FALSE(output.get<bool>("right"));
+  ASSERT_FALSE(output.get<bool>("w"));
+  ASSERT_FALSE(output.get<bool>("a"));
+  ASSERT_FALSE(output.get<bool>("s"));
+  ASSERT_FALSE(output.get<bool>("d"));
+  ASSERT_FALSE(output.get<bool>("x"));
 }
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -19,7 +19,7 @@
 #include "vulp/observation/sources/Keyboard.h"
 
 namespace vulp::observation::sources {
-/*
+
 TEST(Keyboard, WriteOnce) {
   Keyboard keyboard;
   Dictionary observation;
@@ -78,36 +78,8 @@ TEST(Keyboard, ReadArrows) {
   ASSERT_FALSE(output.get<bool>("s"));
   ASSERT_FALSE(output.get<bool>("d"));
   ASSERT_FALSE(output.get<bool>("x"));
-}*/
-
-TEST(Keyboard, ReadArrowsWithGarbage) {
-  // We cannot write directly to STDIN, so we'll redirect a file to it
-  char* tmpfn = tmpnam(nullptr);
-  std::ofstream tmpf(tmpfn);
-  tmpf << "prefix" << LEFT_BYTES; // Garbage bytes before the arrow
-  tmpf.close();
-
-  freopen(tmpfn, "r", stdin);
-
-  Keyboard keyboard = Keyboard();
-
-  Dictionary observation;
-  keyboard.write(observation);
-
-  const auto& output = observation(keyboard.prefix());
-  ASSERT_TRUE(output.get<bool>("key_pressed"));
-  ASSERT_TRUE(output.get<bool>("left"));
-  ASSERT_FALSE(output.get<bool>("up"));
-  ASSERT_FALSE(output.get<bool>("down"));
-  ASSERT_FALSE(output.get<bool>("right"));
-  ASSERT_FALSE(output.get<bool>("w"));
-  ASSERT_FALSE(output.get<bool>("a"));
-  ASSERT_FALSE(output.get<bool>("s"));
-  ASSERT_FALSE(output.get<bool>("d"));
-  ASSERT_FALSE(output.get<bool>("x"));
 }
 
-/*
 TEST(Keyboard, ReadEmptySTDIN) {
   fflush(stdin);  // Clear STDIN
 
@@ -127,6 +99,6 @@ TEST(Keyboard, ReadEmptySTDIN) {
   ASSERT_FALSE(output.get<bool>("s"));
   ASSERT_FALSE(output.get<bool>("d"));
   ASSERT_FALSE(output.get<bool>("x"));
-}*/
+}
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -19,7 +19,7 @@
 #include "vulp/observation/sources/Keyboard.h"
 
 namespace vulp::observation::sources {
-
+/*
 TEST(Keyboard, WriteOnce) {
   Keyboard keyboard;
   Dictionary observation;
@@ -28,9 +28,9 @@ TEST(Keyboard, WriteOnce) {
 
 TEST(Keyboard, ReadAlphabetical) {
   // We cannot write directly to STDIN, so we'll redirect a file to it
-  char *tmpfn = tmpnam(nullptr);
+  char* tmpfn = tmpnam(nullptr);
   std::ofstream tmpf(tmpfn);
-  tmpf << "A"; //(unsigned char[]){'A'};
+  tmpf << "A";  //(unsigned char[]){'A'};
   tmpf.close();
 
   freopen(tmpfn, "r", stdin);
@@ -43,7 +43,7 @@ TEST(Keyboard, ReadAlphabetical) {
   const auto& output = observation(keyboard.prefix());
   ASSERT_TRUE(output.get<bool>("key_pressed"));
   ASSERT_FALSE(output.get<bool>("left"));
-  ASSERT_FALSE(output.get<bool>("up")); 
+  ASSERT_FALSE(output.get<bool>("up"));
   ASSERT_FALSE(output.get<bool>("down"));
   ASSERT_FALSE(output.get<bool>("right"));
   ASSERT_FALSE(output.get<bool>("w"));
@@ -55,7 +55,7 @@ TEST(Keyboard, ReadAlphabetical) {
 
 TEST(Keyboard, ReadArrows) {
   // We cannot write directly to STDIN, so we'll redirect a file to it
-  char *tmpfn = tmpnam(nullptr);
+  char* tmpfn = tmpnam(nullptr);
   std::ofstream tmpf(tmpfn);
   tmpf << LEFT_BYTES;
   tmpf.close();
@@ -70,7 +70,34 @@ TEST(Keyboard, ReadArrows) {
   const auto& output = observation(keyboard.prefix());
   ASSERT_TRUE(output.get<bool>("key_pressed"));
   ASSERT_TRUE(output.get<bool>("left"));
-  ASSERT_FALSE(output.get<bool>("up")); 
+  ASSERT_FALSE(output.get<bool>("up"));
+  ASSERT_FALSE(output.get<bool>("down"));
+  ASSERT_FALSE(output.get<bool>("right"));
+  ASSERT_FALSE(output.get<bool>("w"));
+  ASSERT_FALSE(output.get<bool>("a"));
+  ASSERT_FALSE(output.get<bool>("s"));
+  ASSERT_FALSE(output.get<bool>("d"));
+  ASSERT_FALSE(output.get<bool>("x"));
+}*/
+
+TEST(Keyboard, ReadArrowsWithGarbage) {
+  // We cannot write directly to STDIN, so we'll redirect a file to it
+  char* tmpfn = tmpnam(nullptr);
+  std::ofstream tmpf(tmpfn);
+  tmpf << "prefix" << LEFT_BYTES; // Garbage bytes before the arrow
+  tmpf.close();
+
+  freopen(tmpfn, "r", stdin);
+
+  Keyboard keyboard = Keyboard();
+
+  Dictionary observation;
+  keyboard.write(observation);
+
+  const auto& output = observation(keyboard.prefix());
+  ASSERT_TRUE(output.get<bool>("key_pressed"));
+  ASSERT_TRUE(output.get<bool>("left"));
+  ASSERT_FALSE(output.get<bool>("up"));
   ASSERT_FALSE(output.get<bool>("down"));
   ASSERT_FALSE(output.get<bool>("right"));
   ASSERT_FALSE(output.get<bool>("w"));
@@ -80,8 +107,9 @@ TEST(Keyboard, ReadArrows) {
   ASSERT_FALSE(output.get<bool>("x"));
 }
 
+/*
 TEST(Keyboard, ReadEmptySTDIN) {
-  fflush(stdin); // Clear STDIN
+  fflush(stdin);  // Clear STDIN
 
   Keyboard keyboard = Keyboard();
 
@@ -91,7 +119,7 @@ TEST(Keyboard, ReadEmptySTDIN) {
   const auto& output = observation(keyboard.prefix());
   ASSERT_FALSE(output.get<bool>("key_pressed"));
   ASSERT_FALSE(output.get<bool>("left"));
-  ASSERT_FALSE(output.get<bool>("up")); 
+  ASSERT_FALSE(output.get<bool>("up"));
   ASSERT_FALSE(output.get<bool>("down"));
   ASSERT_FALSE(output.get<bool>("right"));
   ASSERT_FALSE(output.get<bool>("w"));
@@ -99,6 +127,6 @@ TEST(Keyboard, ReadEmptySTDIN) {
   ASSERT_FALSE(output.get<bool>("s"));
   ASSERT_FALSE(output.get<bool>("d"));
   ASSERT_FALSE(output.get<bool>("x"));
-}
+}*/
 
 }  // namespace vulp::observation::sources

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -42,8 +42,12 @@ TEST(Keyboard, ReadAlphabetical) {
 
   const auto& output = observation(keyboard.prefix());
   ASSERT_TRUE(output.get<bool>("key_pressed"));
-  ASSERT_TRUE(output.get<bool>("A"));
+  ASSERT_FALSE(output.get<bool>("LEFT"));
+  ASSERT_FALSE(output.get<bool>("UP")); 
+  ASSERT_FALSE(output.get<bool>("DOWN"));
+  ASSERT_FALSE(output.get<bool>("RIGHT"));
   ASSERT_FALSE(output.get<bool>("W"));
+  ASSERT_TRUE(output.get<bool>("A"));
   ASSERT_FALSE(output.get<bool>("S"));
   ASSERT_FALSE(output.get<bool>("D"));
   ASSERT_FALSE(output.get<bool>("X"));

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -42,15 +42,15 @@ TEST(Keyboard, ReadAlphabetical) {
 
   const auto& output = observation(keyboard.prefix());
   ASSERT_TRUE(output.get<bool>("key_pressed"));
-  ASSERT_FALSE(output.get<bool>("LEFT"));
-  ASSERT_FALSE(output.get<bool>("UP")); 
-  ASSERT_FALSE(output.get<bool>("DOWN"));
-  ASSERT_FALSE(output.get<bool>("RIGHT"));
-  ASSERT_FALSE(output.get<bool>("W"));
-  ASSERT_TRUE(output.get<bool>("A"));
-  ASSERT_FALSE(output.get<bool>("S"));
-  ASSERT_FALSE(output.get<bool>("D"));
-  ASSERT_FALSE(output.get<bool>("X"));
+  ASSERT_FALSE(output.get<bool>("left"));
+  ASSERT_FALSE(output.get<bool>("up")); 
+  ASSERT_FALSE(output.get<bool>("down"));
+  ASSERT_FALSE(output.get<bool>("right"));
+  ASSERT_FALSE(output.get<bool>("w"));
+  ASSERT_TRUE(output.get<bool>("a"));
+  ASSERT_FALSE(output.get<bool>("s"));
+  ASSERT_FALSE(output.get<bool>("d"));
+  ASSERT_FALSE(output.get<bool>("x"));
 }
 
 TEST(Keyboard, ReadArrows) {

--- a/observation/sources/tests/KeyboardTest.cpp
+++ b/observation/sources/tests/KeyboardTest.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Inria
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <fstream>
+
+#include "gtest/gtest.h"
+#include "vulp/observation/sources/Keyboard.h"
+
+namespace vulp::observation::sources {
+
+TEST(Keyboard, WriteOnce) {
+  Keyboard keyboard;
+  Dictionary observation;
+  ASSERT_NO_THROW(keyboard.write(observation));
+}
+
+TEST(Joystick, ReadButtons) {
+  // We cannot write directly to STDIN, so we'll redirect a file to it
+  char *tmpfn = tmpnam(nullptr);
+  std::ofstream tmpf(tmpfn);
+  tmpf << "A"; //(unsigned char[]){'A'};
+  tmpf.close();
+
+  freopen(tmpfn, "r", stdin);
+
+  Keyboard keyboard = Keyboard();
+
+  Dictionary observation;
+  keyboard.write(observation);
+
+  const auto& output = observation(keyboard.prefix());
+  ASSERT_TRUE(output.get<bool>("key_pressed"));
+  ASSERT_TRUE(output.get<bool>("A"));
+  ASSERT_FALSE(output.get<bool>("W"));
+  ASSERT_FALSE(output.get<bool>("S"));
+  ASSERT_FALSE(output.get<bool>("D"));
+  ASSERT_FALSE(output.get<bool>("X"));
+}
+
+TEST(Joystick, ReadArrows) {
+  // We cannot write directly to STDIN, so we'll redirect a file to it
+  char *tmpfn = tmpnam(nullptr);
+  std::ofstream tmpf(tmpfn);
+  tmpf << LEFT_BYTES;
+  tmpf.close();
+
+  freopen(tmpfn, "r", stdin);
+
+  Keyboard keyboard = Keyboard();
+
+  Dictionary observation;
+  keyboard.write(observation);
+
+  const auto& output = observation(keyboard.prefix());
+  ASSERT_TRUE(output.get<bool>("key_pressed"));
+  ASSERT_TRUE(output.get<bool>("LEFT"));
+  ASSERT_FALSE(output.get<bool>("UP")); 
+  ASSERT_FALSE(output.get<bool>("DOWN"));
+  ASSERT_FALSE(output.get<bool>("RIGHT"));
+  ASSERT_FALSE(output.get<bool>("W"));
+  ASSERT_FALSE(output.get<bool>("A"));
+  ASSERT_FALSE(output.get<bool>("S"));
+  ASSERT_FALSE(output.get<bool>("D"));
+  ASSERT_FALSE(output.get<bool>("X"));
+}
+
+TEST(Joystick, ReadNothing) {
+  Keyboard keyboard = Keyboard();
+
+  Dictionary observation;
+  keyboard.write(observation);
+
+  const auto& output = observation(keyboard.prefix());
+  ASSERT_FALSE(output.get<bool>("key_pressed"));
+  ASSERT_FALSE(output.get<bool>("LEFT"));
+  ASSERT_FALSE(output.get<bool>("UP")); 
+  ASSERT_FALSE(output.get<bool>("DOWN"));
+  ASSERT_FALSE(output.get<bool>("RIGHT"));
+  ASSERT_FALSE(output.get<bool>("W"));
+  ASSERT_FALSE(output.get<bool>("A"));
+  ASSERT_FALSE(output.get<bool>("S"));
+  ASSERT_FALSE(output.get<bool>("D"));
+  ASSERT_FALSE(output.get<bool>("X"));
+}
+
+}  // namespace vulp::observation::sources


### PR DESCRIPTION
This PR introduces a portable keyboard observer, inspired by this [blog post](https://www.flipcode.com/archives/_kbhit_for_Linux.shtml).

To the best of my knowledge, there exists no portable way of reading keyboard device events (like we couldn't find one for Joystick, either). This observer therefore reads from the standard input to map incoming characters to respective keys (e.g. `'a' -> A`,` 'A' -> a`).

ASCII characters are encoded by a single byte, and their byte values are platform independent.

Other non-ASCII keys, such as arrow keys, write to the standard input, however, the specific sequence is platform specific. I tried decoding them on my macOS Ventura and on an Ubuntu 22.04 VM.

The implementation should also work over SSH, so it should be possible to run the observer on Upkie and control over SSH.

**Features:**

1. Portable implementation (ASCII alphanumericals are guaranteed to work everywhere AFAIK)
2. Support for non-ASCII keys such as arrow keys (we should discuss if we want to keep this or not)
3. SSH support as a by-product of the followed approach

**Limitations:**
1. Arrow key byte sequences tested on only two machines
2. No support for simultaneous key presses
