### PR TITLE
Add base velocity to initial state in Bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Breaking:** Add "reset" sub-dictionary to Bullet interface config
 - BulletInterface: Refactor internal reset functions
 - Update mpacklog.cpp to v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- BulletInterface: Extend initial state to include the floating base velocity
 - SpineInterface: Mention spine we are waiting for at startup
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- BulletInterface: Refactor internal reset functions
 - Update mpacklog.cpp to v3.1.0
 
 ## [1.4.0] - 2023/08/22

--- a/vulp/actuation/BulletInterface.cpp
+++ b/vulp/actuation/BulletInterface.cpp
@@ -105,13 +105,6 @@ void BulletInterface::reset(const Dictionary& config) {
   reset_joint_angles();
 }
 
-void BulletInterface::reset_joint_angles() {
-  const int nb_joints = bullet_.getNumJoints(robot_);
-  for (int joint_index = 0; joint_index < nb_joints; ++joint_index) {
-    bullet_.resetJointState(robot_, joint_index, 0.0);
-  }
-}
-
 void BulletInterface::reset_base_state(
     const Eigen::Vector3d& position_base_in_world,
     const Eigen::Quaterniond& orientation_base_in_world,
@@ -128,6 +121,13 @@ void BulletInterface::reset_base_state(
   bullet_.resetBaseVelocity(
       robot_, bullet_from_eigen(linear_velocity_base_to_world_in_world),
       bullet_from_eigen(angular_velocity_base_in_world));
+}
+
+void BulletInterface::reset_joint_angles() {
+  const int nb_joints = bullet_.getNumJoints(robot_);
+  for (int joint_index = 0; joint_index < nb_joints; ++joint_index) {
+    bullet_.resetJointState(robot_, joint_index, 0.0);
+  }
 }
 
 void BulletInterface::cycle(

--- a/vulp/actuation/BulletInterface.cpp
+++ b/vulp/actuation/BulletInterface.cpp
@@ -98,8 +98,8 @@ BulletInterface::~BulletInterface() { bullet_.disconnect(); }
 void BulletInterface::reset(const Dictionary& config) {
   params_.configure(config);
   bullet_.setTimeStep(params_.dt);
-  reset_base_state(params_.position_init_base_in_world,
-                   params_.orientation_init_base_in_world,
+  reset_base_state(params_.position_base_in_world,
+                   params_.orientation_base_in_world,
                    params_.linear_velocity_base_to_world_in_world,
                    params_.angular_velocity_base_in_base);
   reset_joint_angles();

--- a/vulp/actuation/BulletInterface.cpp
+++ b/vulp/actuation/BulletInterface.cpp
@@ -98,10 +98,10 @@ BulletInterface::~BulletInterface() { bullet_.disconnect(); }
 void BulletInterface::reset(const Dictionary& config) {
   params_.configure(config);
   bullet_.setTimeStep(params_.dt);
-  reset_base_pose(params_.position_init_base_in_world,
-                  params_.orientation_init_base_in_world);
-  reset_base_velocity(params_.linear_velocity_base_in_world,
-                      params_.angular_velocity_base_in_base);
+  reset_base_state(params_.position_init_base_in_world,
+                   params_.orientation_init_base_in_world,
+                   params_.linear_velocity_base_to_world_in_world,
+                   params_.angular_velocity_base_in_base);
   reset_joint_angles();
 }
 
@@ -112,17 +112,23 @@ void BulletInterface::reset_joint_angles() {
   }
 }
 
-void BulletInterface::reset_base_pose(
+void BulletInterface::reset_base_state(
     const Eigen::Vector3d& position_base_in_world,
-    const Eigen::Quaterniond& orientation_base_in_world) {
-  const auto init_pos = bullet_from_eigen(position_base_in_world);
-  const auto init_quat = bullet_from_eigen(orientation_base_in_world);
-  bullet_.resetBasePositionAndOrientation(robot_, init_pos, init_quat);
-}
+    const Eigen::Quaterniond& orientation_base_in_world,
+    const Eigen::Vector3d& linear_velocity_base_to_world_in_world,
+    const Eigen::Vector3d& angular_velocity_base_in_base) {
+  bullet_.resetBasePositionAndOrientation(
+      robot_, bullet_from_eigen(position_base_in_world),
+      bullet_from_eigen(orientation_base_in_world));
 
-void BulletInterface::reset_base_velocity(
-    const Eigen::Vector3d& linear_velocity_base_in_world,
-    const Eigen::Vector3d& angular_velocity_base_in_base) {}
+  const auto& rotation_base_to_world =
+      orientation_base_in_world;  // transforms are coordinates
+  const Eigen::Vector3d angular_velocity_base_in_world =
+      rotation_base_to_world * angular_velocity_base_in_base;
+  bullet_.resetBaseVelocity(
+      robot_, bullet_from_eigen(linear_velocity_base_to_world_in_world),
+      bullet_from_eigen(angular_velocity_base_in_world));
+}
 
 void BulletInterface::cycle(
     const moteus::Data& data,
@@ -258,6 +264,25 @@ Eigen::Matrix4d BulletInterface::transform_base_to_world() const noexcept {
   T.block<3, 3>(0, 0) = quat.normalized().toRotationMatrix();
   T.block<3, 1>(0, 3) = eigen_from_bullet(position_base_in_world);
   return T;
+}
+
+Eigen::Vector3d BulletInterface::linear_velocity_base_to_world_in_world()
+    const noexcept {
+  btVector3 linear_velocity_base_to_world_in_world;
+  btVector3 _;
+  bullet_.getBaseVelocity(robot_, linear_velocity_base_to_world_in_world, _);
+  return eigen_from_bullet(linear_velocity_base_to_world_in_world);
+}
+
+Eigen::Vector3d BulletInterface::angular_velocity_base_in_base()
+    const noexcept {
+  btVector3 angular_velocity_base_to_world_in_world;
+  btVector3 _;
+  bullet_.getBaseVelocity(robot_, _, angular_velocity_base_to_world_in_world);
+  Eigen::Matrix4d T = transform_base_to_world();
+  Eigen::Matrix3d rotation_base_to_world = T.block<3, 3>(0, 0);
+  return rotation_base_to_world.transpose() *
+         eigen_from_bullet(angular_velocity_base_to_world_in_world);
 }
 
 void BulletInterface::translate_camera_to_robot() {

--- a/vulp/actuation/BulletInterface.cpp
+++ b/vulp/actuation/BulletInterface.cpp
@@ -100,8 +100,8 @@ void BulletInterface::reset(const Dictionary& config) {
   bullet_.setTimeStep(params_.dt);
   reset_base_pose(params_.position_init_base_in_world,
                   params_.orientation_init_base_in_world);
-  // reset_base_velocity(params_.linear_velocity_base_in_world,
-  // params_.angular_velocity_base_in_base);
+  reset_base_velocity(params_.linear_velocity_base_in_world,
+                      params_.angular_velocity_base_in_base);
   reset_joint_angles();
 }
 
@@ -119,6 +119,10 @@ void BulletInterface::reset_base_pose(
   const auto init_quat = bullet_from_eigen(orientation_base_in_world);
   bullet_.resetBasePositionAndOrientation(robot_, init_pos, init_quat);
 }
+
+void BulletInterface::reset_base_velocity(
+    const Eigen::Vector3d& linear_velocity_base_in_world,
+    const Eigen::Vector3d& angular_velocity_base_in_base) {}
 
 void BulletInterface::cycle(
     const moteus::Data& data,

--- a/vulp/actuation/BulletInterface.cpp
+++ b/vulp/actuation/BulletInterface.cpp
@@ -98,17 +98,23 @@ BulletInterface::~BulletInterface() { bullet_.disconnect(); }
 void BulletInterface::reset(const Dictionary& config) {
   params_.configure(config);
   bullet_.setTimeStep(params_.dt);
-  reset_robot(params_.position_init_base_in_world,
-              params_.orientation_init_base_in_world);
+  reset_base_pose(params_.position_init_base_in_world,
+                  params_.orientation_init_base_in_world);
+  // reset_base_velocity(params_.linear_velocity_base_in_world,
+  // params_.angular_velocity_base_in_base);
+  reset_joint_angles();
 }
 
-void BulletInterface::reset_robot(
-    const Eigen::Vector3d& position_base_in_world,
-    const Eigen::Quaterniond& orientation_base_in_world) {
+void BulletInterface::reset_joint_angles() {
   const int nb_joints = bullet_.getNumJoints(robot_);
   for (int joint_index = 0; joint_index < nb_joints; ++joint_index) {
     bullet_.resetJointState(robot_, joint_index, 0.0);
   }
+}
+
+void BulletInterface::reset_base_pose(
+    const Eigen::Vector3d& position_base_in_world,
+    const Eigen::Quaterniond& orientation_base_in_world) {
   const auto init_pos = bullet_from_eigen(position_base_in_world);
   const auto init_quat = bullet_from_eigen(orientation_base_in_world);
   bullet_.resetBasePositionAndOrientation(robot_, init_pos, init_quat);

--- a/vulp/actuation/BulletInterface.h
+++ b/vulp/actuation/BulletInterface.h
@@ -62,14 +62,17 @@ class BulletInterface : public Interface {
       gui = bullet.get<bool>("gui", gui);
       const auto& mode = bullet.get<std::string>("control_mode", "torque");
       use_torque_control = (mode == "torque");
-      position_init_base_in_world = bullet.get<Eigen::Vector3d>(
-          "position_init_base_in_world", Eigen::Vector3d::Zero());
-      orientation_init_base_in_world = bullet.get<Eigen::Quaterniond>(
-          "orientation_init_base_in_world", Eigen::Quaterniond::Identity());
-      linear_velocity_base_to_world_in_world = bullet.get<Eigen::Vector3d>(
-          "linear_velocity_base_to_world_in_world", Eigen::Vector3d::Zero());
-      angular_velocity_base_in_base = bullet.get<Eigen::Vector3d>(
-          "angular_velocity_base_in_base", Eigen::Vector3d::Zero());
+      if (bullet.has("reset")) {
+        const auto& reset = bullet("reset");
+        position_base_in_world = reset.get<Eigen::Vector3d>(
+            "position_base_in_world", Eigen::Vector3d::Zero());
+        orientation_base_in_world = reset.get<Eigen::Quaterniond>(
+            "orientation_base_in_world", Eigen::Quaterniond::Identity());
+        linear_velocity_base_to_world_in_world = reset.get<Eigen::Vector3d>(
+            "linear_velocity_base_to_world_in_world", Eigen::Vector3d::Zero());
+        angular_velocity_base_in_base = reset.get<Eigen::Vector3d>(
+            "angular_velocity_base_in_base", Eigen::Vector3d::Zero());
+      }
       if (bullet.has("torque_control")) {
         torque_control_kd = bullet("torque_control")("kd");
         torque_control_kp = bullet("torque_control")("kp");
@@ -127,18 +130,18 @@ class BulletInterface : public Interface {
     //! Proportional gain for joints in position control mode
     double torque_control_kp = 20.0;
 
-    //! Initial position of the base in the world frame
-    Eigen::Vector3d position_init_base_in_world = Eigen::Vector3d::Zero();
+    //! Position of the base in the world frame upon reset
+    Eigen::Vector3d position_base_in_world = Eigen::Vector3d::Zero();
 
-    //! Initial position of the base in the world frame
-    Eigen::Quaterniond orientation_init_base_in_world =
+    //! Orientation of the base in the world frame upon reset
+    Eigen::Quaterniond orientation_base_in_world =
         Eigen::Quaterniond::Identity();
 
-    //! Initial linear velocity of the base in the world frame
+    //! Linear velocity of the base in the world frame upon reset
     Eigen::Vector3d linear_velocity_base_to_world_in_world =
         Eigen::Vector3d::Zero();
 
-    //! Initial body angular velocity of the base
+    //! Body angular velocity of the base upon reset
     Eigen::Vector3d angular_velocity_base_in_base = Eigen::Vector3d::Zero();
   };
 

--- a/vulp/actuation/BulletInterface.h
+++ b/vulp/actuation/BulletInterface.h
@@ -66,6 +66,10 @@ class BulletInterface : public Interface {
           "position_init_base_in_world", Eigen::Vector3d::Zero());
       orientation_init_base_in_world = bullet.get<Eigen::Quaterniond>(
           "orientation_init_base_in_world", Eigen::Quaterniond::Identity());
+      linear_velocity_base_to_world_in_world = bullet.get<Eigen::Vector3d>(
+          "linear_velocity_base_to_world_in_world", Eigen::Vector3d::Zero());
+      angular_velocity_base_in_base = bullet.get<Eigen::Vector3d>(
+          "angular_velocity_base_in_base", Eigen::Vector3d::Zero());
       if (bullet.has("torque_control")) {
         torque_control_kd = bullet("torque_control")("kd");
         torque_control_kp = bullet("torque_control")("kp");
@@ -131,7 +135,8 @@ class BulletInterface : public Interface {
         Eigen::Quaterniond::Identity();
 
     //! Initial linear velocity of the base in the world frame
-    Eigen::Vector3d linear_velocity_base_in_world = Eigen::Vector3d::Zero();
+    Eigen::Vector3d linear_velocity_base_to_world_in_world =
+        Eigen::Vector3d::Zero();
 
     //! Initial body angular velocity of the base
     Eigen::Vector3d angular_velocity_base_in_base = Eigen::Vector3d::Zero();
@@ -173,27 +178,37 @@ class BulletInterface : public Interface {
   //! Get the groundtruth floating base transform
   Eigen::Matrix4d transform_base_to_world() const noexcept;
 
+  /*! Get the groundtruth floating base linear velocity
+   *
+   * \note This function is only used for testing and does not need to be
+   * optimized.
+   */
+  Eigen::Vector3d linear_velocity_base_to_world_in_world() const noexcept;
+
+  /*! Get the groundtruth floating base angular velocity
+   *
+   * \note This function is only used for testing and does not need to be
+   * optimized.
+   */
+  Eigen::Vector3d angular_velocity_base_in_base() const noexcept;
+
   //! Reset joint angles to zero.
   void reset_joint_angles();
 
-  /*! Reset the pose of the floating base in the world frame.
+  /*! Reset the pose and velocity of the floating base in the world frame.
    *
    * \param[in] position_base_in_world Position of the base in the world frame.
    * \param[in] orientation_base_in_world Orientation of the base in the world
    *     frame.
-   */
-  void reset_base_pose(const Eigen::Vector3d& position_base_in_world,
-                       const Eigen::Quaterniond& orientation_base_in_world);
-
-  /*! Reset the velocity of the floating base in the world frame.
-   *
-   * \param[in] linear_velocity_base_in_world Linear velocity of the base in
-   *     the world frame.
+   * \param[in] linear_velocity_base_to_world_in_world Linear velocity of the
+   *     base in the world frame.
    * \param[in] angular_velocity_base_in_base Body angular velocity of the base
    *     (in the base frame).
    */
-  void reset_base_velocity(
-      const Eigen::Vector3d& linear_velocity_base_in_world,
+  void reset_base_state(
+      const Eigen::Vector3d& position_base_in_world,
+      const Eigen::Quaterniond& orientation_base_in_world,
+      const Eigen::Vector3d& linear_velocity_base_to_world_in_world,
       const Eigen::Vector3d& angular_velocity_base_in_base);
 
   //! Maximum torque for each joint

--- a/vulp/actuation/BulletInterface.h
+++ b/vulp/actuation/BulletInterface.h
@@ -167,14 +167,17 @@ class BulletInterface : public Interface {
   //! Get the groundtruth floating base transform
   Eigen::Matrix4d transform_base_to_world() const noexcept;
 
-  /*! Reset joint angles and the robot's position in the world frame.
+  //! Reset joint angles to zero.
+  void reset_joint_angles();
+
+  /*! Reset the pose of the floating base in the world frame.
    *
    * \param[in] position_base_in_world Position of the base in the world frame.
    * \param[in] orientation_base_in_world Orientation of the base in the world
    *     frame.
    */
-  void reset_robot(const Eigen::Vector3d& position_base_in_world,
-                   const Eigen::Quaterniond& orientation_base_in_world);
+  void reset_base_pose(const Eigen::Vector3d& position_base_in_world,
+                       const Eigen::Quaterniond& orientation_base_in_world);
 
   //! Maximum torque for each joint
   const std::map<std::string, double>& max_torque() {

--- a/vulp/actuation/BulletInterface.h
+++ b/vulp/actuation/BulletInterface.h
@@ -129,6 +129,12 @@ class BulletInterface : public Interface {
     //! Initial position of the base in the world frame
     Eigen::Quaterniond orientation_init_base_in_world =
         Eigen::Quaterniond::Identity();
+
+    //! Initial linear velocity of the base in the world frame
+    Eigen::Vector3d linear_velocity_base_in_world = Eigen::Vector3d::Zero();
+
+    //! Initial body angular velocity of the base
+    Eigen::Vector3d angular_velocity_base_in_base = Eigen::Vector3d::Zero();
   };
 
   /*! Initialize interface.
@@ -178,6 +184,17 @@ class BulletInterface : public Interface {
    */
   void reset_base_pose(const Eigen::Vector3d& position_base_in_world,
                        const Eigen::Quaterniond& orientation_base_in_world);
+
+  /*! Reset the velocity of the floating base in the world frame.
+   *
+   * \param[in] linear_velocity_base_in_world Linear velocity of the base in
+   *     the world frame.
+   * \param[in] angular_velocity_base_in_base Body angular velocity of the base
+   *     (in the base frame).
+   */
+  void reset_base_velocity(
+      const Eigen::Vector3d& linear_velocity_base_in_world,
+      const Eigen::Vector3d& angular_velocity_base_in_base);
 
   //! Maximum torque for each joint
   const std::map<std::string, double>& max_torque() {

--- a/vulp/actuation/tests/BulletInterfaceTest.cpp
+++ b/vulp/actuation/tests/BulletInterfaceTest.cpp
@@ -104,13 +104,17 @@ TEST_F(BulletInterfaceTest, CycleDoesntThrow) {
       interface_->cycle(data_, [](const moteus::Output& output) {}));
 }
 
-TEST_F(BulletInterfaceTest, ResetBasePositionAndOrientation) {
+TEST_F(BulletInterfaceTest, ResetBaseState) {
   Dictionary config;
   config("bullet")("gui") = false;
   config("bullet")("orientation_init_base_in_world") =
       Eigen::Quaterniond(0.707, 0.0, -0.707, 0.0);
   config("bullet")("position_init_base_in_world") =
       Eigen::Vector3d(0.0, 0.0, 1.0);
+  config("bullet")("linear_velocity_base_to_world_in_world") =
+      Eigen::Vector3d(4.0, 5.0, 6.0);
+  config("bullet")("angular_velocity_base_in_base") =
+      Eigen::Vector3d(7.0, 8.0, 9.0);
   interface_->reset(config);
 
   const Eigen::Matrix4d T = interface_->transform_base_to_world();
@@ -125,6 +129,17 @@ TEST_F(BulletInterfaceTest, ResetBasePositionAndOrientation) {
   ASSERT_DOUBLE_EQ(p.x(), 0.0);
   ASSERT_DOUBLE_EQ(p.y(), 0.0);
   ASSERT_DOUBLE_EQ(p.z(), 1.0);
+
+  const Eigen::Vector3d v =
+      interface_->linear_velocity_base_to_world_in_world();
+  ASSERT_DOUBLE_EQ(v.x(), 4.0);
+  ASSERT_DOUBLE_EQ(v.y(), 5.0);
+  ASSERT_DOUBLE_EQ(v.z(), 6.0);
+
+  const Eigen::Vector3d omega = interface_->angular_velocity_base_in_base();
+  ASSERT_NEAR(omega.x(), 7.0, 1e-3);
+  ASSERT_NEAR(omega.y(), 8.0, 1e-3);
+  ASSERT_NEAR(omega.z(), 9.0, 7e-3);
 }
 
 }  // namespace vulp::actuation

--- a/vulp/actuation/tests/BulletInterfaceTest.cpp
+++ b/vulp/actuation/tests/BulletInterfaceTest.cpp
@@ -107,10 +107,9 @@ TEST_F(BulletInterfaceTest, CycleDoesntThrow) {
 TEST_F(BulletInterfaceTest, ResetBaseState) {
   Dictionary config;
   config("bullet")("gui") = false;
-  config("bullet")("orientation_init_base_in_world") =
+  config("bullet")("orientation_base_in_world") =
       Eigen::Quaterniond(0.707, 0.0, -0.707, 0.0);
-  config("bullet")("position_init_base_in_world") =
-      Eigen::Vector3d(0.0, 0.0, 1.0);
+  config("bullet")("position_base_in_world") = Eigen::Vector3d(0.0, 0.0, 1.0);
   config("bullet")("linear_velocity_base_to_world_in_world") =
       Eigen::Vector3d(4.0, 5.0, 6.0);
   config("bullet")("angular_velocity_base_in_base") =

--- a/vulp/actuation/tests/BulletInterfaceTest.cpp
+++ b/vulp/actuation/tests/BulletInterfaceTest.cpp
@@ -107,12 +107,13 @@ TEST_F(BulletInterfaceTest, CycleDoesntThrow) {
 TEST_F(BulletInterfaceTest, ResetBaseState) {
   Dictionary config;
   config("bullet")("gui") = false;
-  config("bullet")("orientation_base_in_world") =
+  config("bullet")("reset")("orientation_base_in_world") =
       Eigen::Quaterniond(0.707, 0.0, -0.707, 0.0);
-  config("bullet")("position_base_in_world") = Eigen::Vector3d(0.0, 0.0, 1.0);
-  config("bullet")("linear_velocity_base_to_world_in_world") =
+  config("bullet")("reset")("position_base_in_world") =
+      Eigen::Vector3d(0.0, 0.0, 1.0);
+  config("bullet")("reset")("linear_velocity_base_to_world_in_world") =
       Eigen::Vector3d(4.0, 5.0, 6.0);
-  config("bullet")("angular_velocity_base_in_base") =
+  config("bullet")("reset")("angular_velocity_base_in_base") =
       Eigen::Vector3d(7.0, 8.0, 9.0);
   interface_->reset(config);
 

--- a/vulp/actuation/tests/bullet_utils_test.cpp
+++ b/vulp/actuation/tests/bullet_utils_test.cpp
@@ -89,11 +89,11 @@ TEST_F(BulletTest, IMULinearAccelerationSeesGravityInFreeFall) {
   bullet_->setTimeStep(dt);
 
   // Rotate the base so that the IMU frame has its x-axis downward
-  auto position_init_base_in_world = btVector3(0., 0., 0.);
-  auto orientation_init_base_in_world =
+  auto position_base_in_world = btVector3(0., 0., 0.);
+  auto orientation_base_in_world =
       bullet_->getQuaternionFromEuler(btVector3(0., -M_PI / 2, 0.));
-  bullet_->resetBasePositionAndOrientation(robot_, position_init_base_in_world,
-                                           orientation_init_base_in_world);
+  bullet_->resetBasePositionAndOrientation(robot_, position_base_in_world,
+                                           orientation_base_in_world);
 
   BulletImuData imu_data;
   read_imu_data(imu_data, *bullet_, robot_, imu_link_index, dt);


### PR DESCRIPTION
- **Breaking:** Add "reset" sub-dictionary to Bullet interface config
- BulletInterface: Refactor internal reset functions
- BulletInterface: Extend initial state to include the floating base velocity
