### PR TITLE
Update palimpsest to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - **Breaking:** Add "reset" sub-dictionary to Bullet interface config
+- Action dictionaries read by the spine are now fully logged
 - BulletInterface: Refactor internal reset functions
 - Update mpacklog.cpp to v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - BulletInterface: Refactor internal reset functions
 - Update mpacklog.cpp to v3.1.0
 
+### Fixed
+
+- Clear configuration dictionary when resetting the spine
+
 ## [1.4.0] - 2023/08/22
 
 ### Added
@@ -30,6 +34,7 @@ All notable changes to this project will be documented in this file.
 ## [1.3.0] - 2023/07/24
 
 ### Added
+
 - Portable and SSH-compatible Keyboard source
 - Support macOS operating systems (with help from @boragokbakan)
 - Virtual destructor to the main ``Interface`` class

--- a/tools/workspace/palimpsest/repository.bzl
+++ b/tools/workspace/palimpsest/repository.bzl
@@ -1,14 +1,14 @@
 # -*- python -*-
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def palimpsest_repository():
     """
     Clone repository from GitHub and make its targets available for binding.
     """
-    git_repository(
+    http_archive(
         name = "palimpsest",
-        remote = "https://github.com/tasts-robots/palimpsest.git",
-        commit = "58a4007b6a1eb5bf3ef8829b364cad9cc127dee5",
-        shallow_since = "1696869735 +0200"
+        sha256 = "244ffe888888bc12d6d5270020993a79e56ddb38f2beafa7647f17cf0192d4c9",
+        strip_prefix = "palimpsest-2.0.0",
+        url = "https://github.com/tasts-robots/palimpsest/archive/refs/tags/v2.0.0.tar.gz",
     )

--- a/tools/workspace/palimpsest/repository.bzl
+++ b/tools/workspace/palimpsest/repository.bzl
@@ -9,6 +9,6 @@ def palimpsest_repository():
     git_repository(
         name = "palimpsest",
         remote = "https://github.com/tasts-robots/palimpsest.git",
-        commit = "4a2d4935ca3394cb036cfad4c9030d3b22b8cc42",
-        shallow_since = "1654192305 +0200"
+        commit = "58a4007b6a1eb5bf3ef8829b364cad9cc127dee5",
+        shallow_since = "1696869735 +0200"
     )

--- a/vulp/observation/ObserverPipeline.cpp
+++ b/vulp/observation/ObserverPipeline.cpp
@@ -16,13 +16,13 @@
 
 #include "vulp/observation/ObserverPipeline.h"
 
-#include <palimpsest/KeyError.h>
+#include <palimpsest/exceptions/KeyError.h>
 
 #include "vulp/observation/ObserverError.h"
 
 namespace vulp::observation {
 
-using palimpsest::KeyError;
+using palimpsest::exceptions::KeyError;
 
 void ObserverPipeline::reset(const Dictionary& config) {
   for (auto observer : observers_) {

--- a/vulp/observation/tests/SchwiftyObserver.h
+++ b/vulp/observation/tests/SchwiftyObserver.h
@@ -17,13 +17,13 @@
 #pragma once
 
 #include <palimpsest/Dictionary.h>
-#include <palimpsest/KeyError.h>
+#include <palimpsest/exceptions/KeyError.h>
 
 #include "vulp/observation/Observer.h"
 
 namespace vulp::observation::tests {
 
-using palimpsest::KeyError;
+using palimpsest::exceptions::KeyError;
 
 //! An observer that gets schwifty
 class SchwiftyObserver : public observation::Observer {

--- a/vulp/observation/tests/ThrowingObserver.h
+++ b/vulp/observation/tests/ThrowingObserver.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <palimpsest/Dictionary.h>
-#include <palimpsest/KeyError.h>
 
 #include "vulp/observation/Observer.h"
 

--- a/vulp/spine/Spine.cpp
+++ b/vulp/spine/Spine.cpp
@@ -135,7 +135,8 @@ void Spine::begin_cycle() {
     Dictionary config;
     const char* data = agent_interface_.data();
     size_t size = agent_interface_.size();
-    config.extend(data, size);
+    config.clear();
+    config.update(data, size);
     reset(config);
   } else if (state_machine_.state() == State::kAct) {
     Dictionary& action = dict_("action");

--- a/vulp/spine/Spine.cpp
+++ b/vulp/spine/Spine.cpp
@@ -62,29 +62,29 @@ Spine::Spine(const Parameters& params, actuation::Interface& actuation,
   agent_interface_.set_request(Request::kNone);
 
   // Initialize internal dictionary
-  Dictionary& observation = dict_("observation");
+  Dictionary& observation = working_dict_("observation");
   observation::observe_time(observation);
-  dict_.insert<double>("time", observation.get<double>("time"));
+  working_dict_.insert<double>("time", observation.get<double>("time"));
 }
 
 void Spine::reset(const Dictionary& config) {
   actuation_.reset(config);
-  dict_("action").clear();
-  actuation_.initialize_action(dict_("action"));
+  working_dict_("action").clear();
+  actuation_.initialize_action(working_dict_("action"));
   observer_pipeline_.reset(config);
 }
 
 void Spine::log_dict() {
-  Dictionary& spine = dict_("spine");
+  Dictionary& spine = working_dict_("spine");
   spine("logger")("last_size") = logger_.last_size();
   spine("state")("cycle_beginning") =
       static_cast<uint32_t>(state_cycle_beginning_);
   spine("state")("cycle_end") = static_cast<uint32_t>(state_cycle_end_);
-  logger_.put(dict_);
+  logger_.put(working_dict_);
 }
 
 void Spine::run() {
-  Dictionary& spine = dict_("spine");
+  Dictionary& spine = working_dict_("spine");
   utils::SynchronousClock clock(frequency_);
   while (state_machine_.state() != State::kOver) {
     cycle();
@@ -139,7 +139,7 @@ void Spine::begin_cycle() {
     config.update(data, size);
     reset(config);
   } else if (state_machine_.state() == State::kAct) {
-    Dictionary& action = dict_("action");
+    Dictionary& action = working_dict_("action");
     const char* data = agent_interface_.data();
     size_t size = agent_interface_.size();
     action.update(data, size);
@@ -148,8 +148,8 @@ void Spine::begin_cycle() {
 
 void Spine::end_cycle() {
   // Write observation if applicable
-  const Dictionary& observation = dict_("observation");
-  dict_("time") = observation.get<double>("time");
+  const Dictionary& observation = working_dict_("observation");
+  working_dict_("time") = observation.get<double>("time");
   if (state_machine_.state() == State::kObserve) {
     size_t size = observation.serialize(ipc_buffer_);
     agent_interface_.write(ipc_buffer_.data(), size);
@@ -162,7 +162,7 @@ void Spine::end_cycle() {
 void Spine::cycle_actuation() {
   try {
     // 1. Observation
-    Dictionary& observation = dict_("observation");
+    Dictionary& observation = working_dict_("observation");
     observation::observe_time(observation);
     observation::observe_servos(observation, actuation_.servo_joint_map(),
                                 latest_replies_);
@@ -183,7 +183,7 @@ void Spine::cycle_actuation() {
         state_machine_.state() == State::kShutdown) {
       actuation_.write_stop_commands();
     } else if (state_machine_.state() == State::kAct) {
-      Dictionary& action = dict_("action");
+      Dictionary& action = working_dict_("action");
       actuation_.write_position_commands(action);
       // TODO(scaron): don't re-send actuation
       // See https://github.com/tasts-robots/vulp/issues/2

--- a/vulp/spine/Spine.h
+++ b/vulp/spine/Spine.h
@@ -166,13 +166,13 @@ class Spine {
   //! Latest IMU data. It is copied and thread-safe.
   actuation::ImuData latest_imu_data_;
 
-  //! All data from observation and control goes to this dictionary
-  palimpsest::Dictionary dict_;
+  //! All data from observation to action goes to this dictionary
+  palimpsest::Dictionary working_dict_;
 
   //! Pipeline of observers, executed in that order
   observation::ObserverPipeline observer_pipeline_;
 
-  //! Logger for the dictionary \ref dict_ produced at each cycle
+  //! Logger for the \ref working_dict_ produced at each cycle
   mpacklog::Logger logger_;
 
   //! Buffer used to serialize/deserialize dictionaries in IPC.

--- a/vulp/spine/tests/SpineTest.cpp
+++ b/vulp/spine/tests/SpineTest.cpp
@@ -63,8 +63,8 @@ class Spine : public vulp::spine::Spine {
     return true;
   }
 
-  //! Get current observation.
-  const palimpsest::Dictionary& dict() { return dict_; }
+  //! Expose internal working dictionary to tests
+  const palimpsest::Dictionary& working_dict() { return working_dict_; }
 
   //! Get current (state of the) state machine.
   const State& state() { return state_machine_.state(); }
@@ -182,8 +182,8 @@ class SpineTest : public ::testing::Test {
 };
 
 TEST_F(SpineTest, ObservationInitializedInConstructor) {
-  ASSERT_TRUE(spine_->dict().has("observation"));
-  ASSERT_TRUE(spine_->dict().has("time"));
+  ASSERT_TRUE(spine_->working_dict().has("observation"));
+  ASSERT_TRUE(spine_->working_dict().has("time"));
 }
 
 TEST_F(SpineTest, InitiallyStopped) {
@@ -193,8 +193,8 @@ TEST_F(SpineTest, InitiallyStopped) {
 TEST_F(SpineTest, ResetConfiguresAction) {
   Dictionary config;
   spine_->reset(config);
-  ASSERT_TRUE(spine_->dict().has("action"));
-  const Dictionary& action = spine_->dict()("action");
+  ASSERT_TRUE(spine_->working_dict().has("action"));
+  const Dictionary& action = spine_->working_dict()("action");
   ASSERT_TRUE(action.has("servo"));
 }
 
@@ -234,7 +234,7 @@ TEST_F(SpineTest, CatchObserverErrors) {
 
 TEST_F(SpineTest, DontRunObserversWhenStopped) {
   ASSERT_EQ(spine_->state(), State::kSendStops);
-  const Dictionary& observation = spine_->dict()("observation");
+  const Dictionary& observation = spine_->working_dict()("observation");
   spine_->cycle();
   ASSERT_FALSE(observation.has("schwifty"));
 
@@ -248,7 +248,7 @@ TEST_F(SpineTest, SetObservationOnIdle) {
   start_spine();
   ASSERT_EQ(spine_->state(), State::kIdle);
   spine_->cycle();
-  const Dictionary& observation = spine_->dict()("observation");
+  const Dictionary& observation = spine_->working_dict()("observation");
   ASSERT_TRUE(observation.get<bool>("schwifty"));
 }
 
@@ -256,7 +256,7 @@ TEST_F(SpineTest, WriteObservationOnRequest) {
   start_spine();
   write_mmap_request(Request::kObservation);
   spine_->cycle();
-  const Dictionary& observation = spine_->dict()("observation");
+  const Dictionary& observation = spine_->working_dict()("observation");
   ASSERT_TRUE(observation.get<bool>("schwifty"));
 }
 
@@ -284,7 +284,7 @@ TEST_F(SpineTest, ShutdownExecutesFixedNumberOfStopCycles) {
 TEST_F(SpineTest, ResetInitializesAction) {
   Dictionary config;
   spine_->reset(config);
-  const Dictionary& spine_dict = spine_->dict();
+  const Dictionary& spine_dict = spine_->working_dict();
   ASSERT_TRUE(spine_dict.has("action"));
   ASSERT_TRUE(spine_dict("action").has("servo"));
   ASSERT_TRUE(spine_dict("action")("servo").has("bar"));
@@ -302,7 +302,7 @@ TEST_F(SpineTest, SpineReadsAction) {
                          '\x00', '\x00', '\x00'};
   const size_t size = 31;
   write_mmap_data(data, size);
-  const Dictionary& action = spine_->dict()("action");
+  const Dictionary& action = spine_->working_dict()("action");
   write_mmap_request(Request::kAction);
   ASSERT_TRUE(std::isnan(action("servo")("bar").get<double>("position")));
   ASSERT_EQ(spine_->state(), State::kIdle);


### PR DESCRIPTION
Although this PR only updates *palimpsest* to version 2, there is a major change in that version that directly impacts spine behaviors:

- Action dictionaries read by the spine are now fully logged (including keys not used by the spine itself)

As a consequence, we will be able to clear out asyncio loggers on the Python side, leaving the spine as the single source of truth for logs.

# Performance regression check

```pythono
foxplot([data.spine.clock.measured_period, data.spine.clock.slack], right=[data.spine.clock.skip_count])
```

## Before

``2023-10-16_185356_pi3hat_spine.mpack``

![image](https://github.com/tasts-robots/vulp/assets/1189580/39eb2107-c314-49d6-b3de-ae84f5b36254)

## After

``2023-10-16_190040_pi3hat_spine.mpack``

![image](https://github.com/tasts-robots/vulp/assets/1189580/55333259-0fc6-438c-9c83-10bc8b61fcec)
